### PR TITLE
Add ancestor, precedingSibling and followingSibling M1 extension methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres _loosely_ to [Semantic Versioning](https://semver.org/s
 
 ### Added
 
-- Add following M1 extensions axes methods: Ancestor, PrecedingSibling, FollowingSibling
+- Add following M1 extensions axes methods: Ancestor, PrecedingSiblings, FollowingSiblings
 - Generator adds descriptions to generated classes from model annotations.
 - Language (de-)Serialization can handle annotations on languages.
 - Generate interface for each factory; factory implementation methods are `virtual` now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres _loosely_ to [Semantic Versioning](https://semver.org/s
 
 ### Added
 
+- Add following M1 extensions axes methods: Ancestor, PrecedingSibling, FollowingSibling
 - Generator adds descriptions to generated classes from model annotations.
 - Language (de-)Serialization can handle annotations on languages.
 - Generate interface for each factory; factory implementation methods are `virtual` now.

--- a/src/LionWeb-CSharp/core/M1/M1Extensions.cs
+++ b/src/LionWeb-CSharp/core/M1/M1Extensions.cs
@@ -199,7 +199,7 @@ public static class M1Extensions
     /// <param name="self">Base node to find ancestor of.</param>
     /// <param name="includeSelf">If true, the result includes <paramref name="self"/>.</param>
     /// <typeparam name="T"></typeparam>
-    /// <returns>The first ancestor of <paramref name="self"/> that matches with type <typeparamref name="T"/> or null </returns>
+    /// <returns>The first ancestor of <paramref name="self"/> that matches with type <typeparamref name="T"/> or <c>null</c> </returns>
     public static T? Ancestor<T>(this INode self, bool includeSelf = false) where T : INode =>
         self.Ancestors(includeSelf)
             .OfType<T>()

--- a/src/LionWeb-CSharp/core/M1/M1Extensions.cs
+++ b/src/LionWeb-CSharp/core/M1/M1Extensions.cs
@@ -87,7 +87,7 @@ public static class M1Extensions
         list.Insert(index + 1, newSuccessor);
         parent.Set(containment, list);
     }
-    
+
     /// <summary>
     /// Returns all the preceding siblings of the base node <param name="self"></param>
     /// Optionally includes <paramref name="self"/>.
@@ -99,7 +99,7 @@ public static class M1Extensions
     /// <param name="includeSelf">If true, the result includes <paramref name="self"/>.</param>
     /// <returns>List of preceding siblings of <param name="self"></param>.</returns>
     /// <exception cref="TreeShapeException">If <paramref name="self"/> has no parent, or is not a child in a multiple containment.</exception>
-    public static IEnumerable<INode> PrecedingSibling(this INode self, bool includeSelf = false)
+    public static IEnumerable<INode> PrecedingSiblings(this INode self, bool includeSelf = false)
     {
         List<INode> list = GetContainmentNodes(self);
         var takeCount = includeSelf ? list.IndexOf(self) + 1 : list.IndexOf(self);
@@ -118,7 +118,7 @@ public static class M1Extensions
     /// <param name="includeSelf">If true, the result includes <paramref name="self"/>.</param>
     /// <returns>List of following siblings of <param name="self"></param>.</returns>
     /// <exception cref="TreeShapeException">If <paramref name="self"/> has no parent, or is not a child in a multiple containment.</exception>
-    public static IEnumerable<INode> FollowingSibling(this INode self, bool includeSelf = false)
+    public static IEnumerable<INode> FollowingSiblings(this INode self, bool includeSelf = false)
     {
         List<INode> list = GetContainmentNodes(self);
         var skipCount = includeSelf ? list.IndexOf(self) : list.IndexOf(self) + 1;
@@ -191,20 +191,20 @@ public static class M1Extensions
         bool includeAnnotations = false) =>
         Children<INode>(self, includeSelf, includeAnnotations);
 
-    
+
     /// <summary>
-    /// Enumerates all direct and indirect parents of <paramref name="self"/> that matches with type <typeparamref name="T"/>
+    /// Returns the first ancestor of <paramref name="self"/> that matches with type <typeparamref name="T"/>
     /// Optionally includes <paramref name="self"/>.
     /// </summary>
     /// <param name="self">Base node to find ancestor of.</param>
     /// <param name="includeSelf">If true, the result includes <paramref name="self"/>.</param>
     /// <typeparam name="T"></typeparam>
-    /// <returns>The first ancestor of <paramref name="self"/> that matches with type <typeparamref name="T"/> or default </returns>
+    /// <returns>The first ancestor of <paramref name="self"/> that matches with type <typeparamref name="T"/> or null </returns>
     public static T? Ancestor<T>(this INode self, bool includeSelf = false) where T : INode =>
         self.Ancestors(includeSelf)
             .OfType<T>()
             .FirstOrDefault();
-    
+
     /// <summary>
     /// Enumerates all direct and indirect parents of <paramref name="self"/>.
     /// Optionally includes <paramref name="self"/>.
@@ -220,19 +220,19 @@ public static class M1Extensions
         INode? parent = self.GetParent();
         if (parent == null)
             throw new TreeShapeException(self, "Cannot get siblings of a node with no parent");
-        
+
         Containment containment = parent.GetContainmentOf(self)!;
         if (!containment.Multiple)
             throw new TreeShapeException(self, "A single containment does not have siblings");
-        
+
         var value = parent.Get(containment);
         if (value is not IEnumerable enumerable)
             // should not happen
             throw new TreeShapeException(self, "A single containment does not have siblings");
-        
+
         return [..containment.AsNodes<INode>(enumerable)];
     }
-    
+
     internal static IEnumerable<T> Descendants<T>(T self, bool includeSelf = false,
         bool includeAnnotations = false) where T : class, IReadableNode
     {

--- a/test/LionWeb-CSharp-Test/tests/nodeapi/AxisTests.cs
+++ b/test/LionWeb-CSharp-Test/tests/nodeapi/AxisTests.cs
@@ -162,8 +162,12 @@ public class AxisTests
         var node = new Coord("n");
         var parent = new Line("p") { Start = node };
         var ancestor = new Geometry("a") { Shapes = [parent] };
+        
         Assert.IsNotNull(node.Ancestor<Shape>());
         Assert.AreEqual(parent, node.Ancestor<Shape>());
+        
+        Assert.IsNotNull(parent.Ancestor<Geometry>());
+        Assert.AreEqual(ancestor, parent.Ancestor<Geometry>());
     }
     
     [TestMethod]
@@ -172,8 +176,12 @@ public class AxisTests
         var node = new Coord("n");
         var parent = new Line("p") { Start = node };
         var ancestor = new Geometry("a") { Shapes = [parent] };
+        
         Assert.IsNotNull(node.Ancestor<Shape>(true));
         Assert.AreEqual(parent, node.Ancestor<Shape>(true));
+        
+        Assert.IsNotNull(parent.Ancestor<Geometry>(true));
+        Assert.AreEqual(ancestor, parent.Ancestor<Geometry>(true));
     }
     
     #endregion

--- a/test/LionWeb-CSharp-Test/tests/nodeapi/AxisTests.cs
+++ b/test/LionWeb-CSharp-Test/tests/nodeapi/AxisTests.cs
@@ -138,6 +138,164 @@ public class AxisTests
 
     #endregion
 
+    #region ancestor
+
+    [TestMethod]
+    public void Ancestor_NoParent()
+    {
+        var node = new Circle("n");
+        Assert.AreEqual(null, node.Ancestor<Shape>(false));
+        Assert.IsNull(node.Ancestor<Shape>(false));
+    }
+
+    [TestMethod]
+    public void Ancestor_NoParent_Self()
+    {
+        var node = new Circle("n");
+        Assert.AreEqual(node, node.Ancestor<Shape>(true));
+        Assert.IsNotNull(node.Ancestor<Shape>(true));
+    }
+    
+    [TestMethod]
+    public void Ancestor_ManyParents()
+    {
+        var node = new Coord("n");
+        var parent = new Line("p") { Start = node };
+        var ancestor = new Geometry("a") { Shapes = [parent] };
+        Assert.IsNotNull(node.Ancestor<Shape>());
+        Assert.AreEqual(parent, node.Ancestor<Shape>());
+    }
+    
+    [TestMethod]
+    public void Ancestor_ManyParents_Self()
+    {
+        var node = new Coord("n");
+        var parent = new Line("p") { Start = node };
+        var ancestor = new Geometry("a") { Shapes = [parent] };
+        Assert.IsNotNull(node.Ancestor<Shape>(true));
+        Assert.AreEqual(parent, node.Ancestor<Shape>(true));
+    }
+    
+    #endregion
+    
+    #region precedingSibling
+    
+    [TestMethod]
+    public void PrecedingSibling()
+    {
+        var circleA = new Circle("a");
+        var circleB = new Circle("b");
+        var circleC = new Circle("c");
+        var circleD = new Circle("d");
+        var ancestor = new Geometry("a") { Shapes = [circleA, circleB, circleC, circleD] };
+        CollectionAssert.AreEqual(new List<INode>{circleA, circleB}, circleC.PrecedingSibling().ToList());
+    }
+    
+    [TestMethod]
+    public void PrecedingSibling_Self()
+    {
+        var circleA = new Circle("a");
+        var circleB = new Circle("b");
+        var circleC = new Circle("c");
+        var circleD = new Circle("d");
+        var ancestor = new Geometry("a") { Shapes = [circleA, circleB, circleC, circleD] };
+        CollectionAssert.AreEqual(new List<INode>{circleA, circleB, circleC}, circleC.PrecedingSibling(true).ToList());
+    }
+    
+    [TestMethod]
+    public void PrecedingSibling_NoParent()
+    {
+        var circleA = new Circle("a");
+        Assert.ThrowsException<TreeShapeException>(() => circleA.PrecedingSibling());
+    }
+    
+    [TestMethod]
+    public void PrecedingSibling_SingleContainment()
+    {
+        var coord = new Coord("coord0");
+        var circle = new Circle("circ0") { Center = coord };
+        Assert.ThrowsException<TreeShapeException>(() => coord.PrecedingSibling());
+    }
+    
+    [TestMethod]
+    public void PrecedingSibling_NoPrecedingSibling()
+    {
+        var circleA = new Circle("a");
+        var circleB = new Circle("b");
+        var ancestor = new Geometry("a") { Shapes = [circleA, circleB] };
+        CollectionAssert.AreEqual(new List<INode>{}, circleA.PrecedingSibling().ToList());
+    }
+    
+    [TestMethod]
+    public void PrecedingSibling_NoPrecedingSibling_Self()
+    {
+        var circleA = new Circle("a");
+        var circleB = new Circle("b");
+        var ancestor = new Geometry("a") { Shapes = [circleA, circleB] };
+        CollectionAssert.AreEqual(new List<INode>{circleA}, circleA.PrecedingSibling(true).ToList());
+    }
+    
+    #endregion
+    
+    #region followingSibling
+    
+    [TestMethod]
+    public void FollowingSibling()
+    {
+        var circleA = new Circle("a");
+        var circleB = new Circle("b");
+        var circleC = new Circle("c");
+        var circleD = new Circle("d");
+        var ancestor = new Geometry("a") { Shapes = [circleA, circleB, circleC, circleD] };
+        CollectionAssert.AreEqual(new List<INode>{circleD}, circleC.FollowingSibling().ToList());
+    }
+    
+    [TestMethod]
+    public void FollowingSibling_Self()
+    {
+        var circleA = new Circle("a");
+        var circleB = new Circle("b");
+        var circleC = new Circle("c");
+        var circleD = new Circle("d");
+        var ancestor = new Geometry("a") { Shapes = [circleA, circleB, circleC, circleD] };
+        CollectionAssert.AreEqual(new List<INode>{circleC, circleD}, circleC.FollowingSibling(true).ToList());
+    }
+    
+    [TestMethod]
+    public void FollowingSibling_NoParent()
+    {
+        var circleA = new Circle("a");
+        Assert.ThrowsException<TreeShapeException>(() => circleA.FollowingSibling());
+    }
+    
+    [TestMethod]
+    public void FollowingSibling_SingleContainment()
+    {
+        var coord = new Coord("coord0");
+        var circle = new Circle("circ0") { Center = coord };
+        Assert.ThrowsException<TreeShapeException>(() => coord.FollowingSibling());
+    }
+    
+    [TestMethod]
+    public void FollowingSibling_NoFollowingSibling()
+    {
+        var circleA = new Circle("a");
+        var circleB = new Circle("b");
+        var ancestor = new Geometry("a") { Shapes = [circleA, circleB] };
+        CollectionAssert.AreEqual(new List<INode>{}, circleB.FollowingSibling().ToList());
+    }
+    
+    [TestMethod]
+    public void FollowingSibling_NoFollowingSibling_Self()
+    {
+        var circleA = new Circle("a");
+        var circleB = new Circle("b");
+        var ancestor = new Geometry("a") { Shapes = [circleA, circleB] };
+        CollectionAssert.AreEqual(new List<INode>{circleB}, circleB.FollowingSibling(true).ToList());
+    }
+    
+    #endregion
+
     #region children
 
     #region noChildren

--- a/test/LionWeb-CSharp-Test/tests/nodeapi/AxisTests.cs
+++ b/test/LionWeb-CSharp-Test/tests/nodeapi/AxisTests.cs
@@ -212,8 +212,8 @@ public class AxisTests
     [TestMethod]
     public void PrecedingSibling_SingleContainment()
     {
-        var coord = new Coord("coord0");
-        var circle = new Circle("circ0") { Center = coord };
+        var coord = new Coord("a");
+        var circle = new Circle("b") { Center = coord };
         Assert.ThrowsException<TreeShapeException>(() => coord.PrecedingSibling());
     }
     
@@ -271,8 +271,8 @@ public class AxisTests
     [TestMethod]
     public void FollowingSibling_SingleContainment()
     {
-        var coord = new Coord("coord0");
-        var circle = new Circle("circ0") { Center = coord };
+        var coord = new Coord("a");
+        var circle = new Circle("b") { Center = coord };
         Assert.ThrowsException<TreeShapeException>(() => coord.FollowingSibling());
     }
     

--- a/test/LionWeb-CSharp-Test/tests/nodeapi/TreeTraversalTests.cs
+++ b/test/LionWeb-CSharp-Test/tests/nodeapi/TreeTraversalTests.cs
@@ -20,7 +20,7 @@ namespace LionWeb.Core.M1.Test;
 using Examples.Shapes.M2;
 
 [TestClass]
-public class AxisTests
+public class TreeTraversalTests
 {
     #region ancestors
 

--- a/test/LionWeb-CSharp-Test/tests/nodeapi/TreeTraversalTests.cs
+++ b/test/LionWeb-CSharp-Test/tests/nodeapi/TreeTraversalTests.cs
@@ -155,39 +155,39 @@ public class TreeTraversalTests
         Assert.AreEqual(node, node.Ancestor<Shape>(true));
         Assert.IsNotNull(node.Ancestor<Shape>(true));
     }
-    
+
     [TestMethod]
     public void Ancestor_ManyParents()
     {
         var node = new Coord("n");
         var parent = new Line("p") { Start = node };
         var ancestor = new Geometry("a") { Shapes = [parent] };
-        
+
         Assert.IsNotNull(node.Ancestor<Shape>());
         Assert.AreEqual(parent, node.Ancestor<Shape>());
-        
+
         Assert.IsNotNull(parent.Ancestor<Geometry>());
         Assert.AreEqual(ancestor, parent.Ancestor<Geometry>());
     }
-    
+
     [TestMethod]
     public void Ancestor_ManyParents_Self()
     {
         var node = new Coord("n");
         var parent = new Line("p") { Start = node };
         var ancestor = new Geometry("a") { Shapes = [parent] };
-        
+
         Assert.IsNotNull(node.Ancestor<Shape>(true));
         Assert.AreEqual(parent, node.Ancestor<Shape>(true));
-        
+
         Assert.IsNotNull(parent.Ancestor<Geometry>(true));
         Assert.AreEqual(ancestor, parent.Ancestor<Geometry>(true));
     }
-    
+
     #endregion
-    
+
     #region precedingSibling
-    
+
     [TestMethod]
     public void PrecedingSibling()
     {
@@ -196,9 +196,9 @@ public class TreeTraversalTests
         var circleC = new Circle("c");
         var circleD = new Circle("d");
         var ancestor = new Geometry("a") { Shapes = [circleA, circleB, circleC, circleD] };
-        CollectionAssert.AreEqual(new List<INode>{circleA, circleB}, circleC.PrecedingSibling().ToList());
+        CollectionAssert.AreEqual(new List<INode> { circleA, circleB }, circleC.PrecedingSiblings().ToList());
     }
-    
+
     [TestMethod]
     public void PrecedingSibling_Self()
     {
@@ -207,46 +207,47 @@ public class TreeTraversalTests
         var circleC = new Circle("c");
         var circleD = new Circle("d");
         var ancestor = new Geometry("a") { Shapes = [circleA, circleB, circleC, circleD] };
-        CollectionAssert.AreEqual(new List<INode>{circleA, circleB, circleC}, circleC.PrecedingSibling(true).ToList());
+        CollectionAssert.AreEqual(new List<INode> { circleA, circleB, circleC },
+            circleC.PrecedingSiblings(true).ToList());
     }
-    
+
     [TestMethod]
     public void PrecedingSibling_NoParent()
     {
         var circleA = new Circle("a");
-        Assert.ThrowsException<TreeShapeException>(() => circleA.PrecedingSibling());
+        Assert.ThrowsException<TreeShapeException>(() => circleA.PrecedingSiblings());
     }
-    
+
     [TestMethod]
     public void PrecedingSibling_SingleContainment()
     {
         var coord = new Coord("a");
         var circle = new Circle("b") { Center = coord };
-        Assert.ThrowsException<TreeShapeException>(() => coord.PrecedingSibling());
+        Assert.ThrowsException<TreeShapeException>(() => coord.PrecedingSiblings());
     }
-    
+
     [TestMethod]
     public void PrecedingSibling_NoPrecedingSibling()
     {
         var circleA = new Circle("a");
         var circleB = new Circle("b");
         var ancestor = new Geometry("a") { Shapes = [circleA, circleB] };
-        CollectionAssert.AreEqual(new List<INode>{}, circleA.PrecedingSibling().ToList());
+        CollectionAssert.AreEqual(new List<INode> { }, circleA.PrecedingSiblings().ToList());
     }
-    
+
     [TestMethod]
     public void PrecedingSibling_NoPrecedingSibling_Self()
     {
         var circleA = new Circle("a");
         var circleB = new Circle("b");
         var ancestor = new Geometry("a") { Shapes = [circleA, circleB] };
-        CollectionAssert.AreEqual(new List<INode>{circleA}, circleA.PrecedingSibling(true).ToList());
+        CollectionAssert.AreEqual(new List<INode> { circleA }, circleA.PrecedingSiblings(true).ToList());
     }
-    
+
     #endregion
-    
+
     #region followingSibling
-    
+
     [TestMethod]
     public void FollowingSibling()
     {
@@ -255,9 +256,9 @@ public class TreeTraversalTests
         var circleC = new Circle("c");
         var circleD = new Circle("d");
         var ancestor = new Geometry("a") { Shapes = [circleA, circleB, circleC, circleD] };
-        CollectionAssert.AreEqual(new List<INode>{circleD}, circleC.FollowingSibling().ToList());
+        CollectionAssert.AreEqual(new List<INode> { circleD }, circleC.FollowingSiblings().ToList());
     }
-    
+
     [TestMethod]
     public void FollowingSibling_Self()
     {
@@ -266,42 +267,42 @@ public class TreeTraversalTests
         var circleC = new Circle("c");
         var circleD = new Circle("d");
         var ancestor = new Geometry("a") { Shapes = [circleA, circleB, circleC, circleD] };
-        CollectionAssert.AreEqual(new List<INode>{circleC, circleD}, circleC.FollowingSibling(true).ToList());
+        CollectionAssert.AreEqual(new List<INode> { circleC, circleD }, circleC.FollowingSiblings(true).ToList());
     }
-    
+
     [TestMethod]
     public void FollowingSibling_NoParent()
     {
         var circleA = new Circle("a");
-        Assert.ThrowsException<TreeShapeException>(() => circleA.FollowingSibling());
+        Assert.ThrowsException<TreeShapeException>(() => circleA.FollowingSiblings());
     }
-    
+
     [TestMethod]
     public void FollowingSibling_SingleContainment()
     {
         var coord = new Coord("a");
         var circle = new Circle("b") { Center = coord };
-        Assert.ThrowsException<TreeShapeException>(() => coord.FollowingSibling());
+        Assert.ThrowsException<TreeShapeException>(() => coord.FollowingSiblings());
     }
-    
+
     [TestMethod]
     public void FollowingSibling_NoFollowingSibling()
     {
         var circleA = new Circle("a");
         var circleB = new Circle("b");
         var ancestor = new Geometry("a") { Shapes = [circleA, circleB] };
-        CollectionAssert.AreEqual(new List<INode>{}, circleB.FollowingSibling().ToList());
+        CollectionAssert.AreEqual(new List<INode> { }, circleB.FollowingSiblings().ToList());
     }
-    
+
     [TestMethod]
     public void FollowingSibling_NoFollowingSibling_Self()
     {
         var circleA = new Circle("a");
         var circleB = new Circle("b");
         var ancestor = new Geometry("a") { Shapes = [circleA, circleB] };
-        CollectionAssert.AreEqual(new List<INode>{circleB}, circleB.FollowingSibling(true).ToList());
+        CollectionAssert.AreEqual(new List<INode> { circleB }, circleB.FollowingSiblings(true).ToList());
     }
-    
+
     #endregion
 
     #region children


### PR DESCRIPTION
This PR includes the following M1 extension methods (mentioned in issue #21) and their tests.

- Ancestor
- PrecedingSiblings
- FollowingSiblings

