### PR TITLE
Introduced ComparerBehaviorConfig.CompareCompatibleClassifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres _loosely_ to [Semantic Versioning](https://semver.org/s
 * Introduced `SerializerBuilder`.
 * Introduced `LanguageDeserializerBuilder`.
 * Introduced delegating implementations for `SerializerHandler`, `DeserializerHandler`, `LanguageDeserializerHandler`.
+* Introduced `ComparerBehaviorConfig.CompareCompatibleClassifier` to configure whether 
+  instances of C# `Annotation` and `Concept` should be considered different.
 ### Fixed
 * `LenientNode` now works properly if keys of features change.
 * Deserializer can now create instances of languages not registered beforehand.

--- a/src/LionWeb.Core/Core/Utilities/Comparer.cs
+++ b/src/LionWeb.Core/Core/Utilities/Comparer.cs
@@ -589,7 +589,7 @@ public class Comparer(IList<IReadableNode?> _left, IList<IReadableNode?> _right)
             case (Annotation leftAnn, Annotation rightAnn):
                 result.AddRange(CompareAnnotation(left, leftAnn, right, rightAnn));
                 break;
-            case (Annotation, Concept) or (Concept, Annotation):
+            case (Annotation, Concept) or (Concept, Annotation) when BehaviorConfig.CompareCompatibleClassifier:
                 result.Add(new IncompatibleClassifierDifference(left, right));
                 break;
         }
@@ -632,15 +632,17 @@ public class Comparer(IList<IReadableNode?> _left, IList<IReadableNode?> _right)
 }
 
 /// <summary>
-/// Configures the behavior of <see cref="System.Collections.Comparer"/>.
+/// Configures the behavior of <see cref="Comparer"/>.
 /// </summary>
 public class ComparerBehaviorConfig
 {
-    // nothing here yet
+    /// Whether we should compare classifier compatibility; defaults to <c>true</c>.
+    /// <seealso cref="IncompatibleClassifierDifference"/>
+    public bool CompareCompatibleClassifier { get; init; } = true;
 }
 
 /// <summary>
-/// Configures the output of <see cref="System.Collections.Comparer"/>.
+/// Configures the output of <see cref="Comparer"/>.
 /// </summary>
 public class ComparerOutputConfig
 {

--- a/src/LionWeb.Core/Core/Utilities/Comparer.cs
+++ b/src/LionWeb.Core/Core/Utilities/Comparer.cs
@@ -592,6 +592,9 @@ public class Comparer(IList<IReadableNode?> _left, IList<IReadableNode?> _right)
             case (Annotation, Concept) or (Concept, Annotation) when BehaviorConfig.CompareCompatibleClassifier:
                 result.Add(new IncompatibleClassifierDifference(left, right));
                 break;
+            case var (leftClassifier, rightClassifier):
+                result.AddRange(CompareClassifier(left, leftClassifier, right, rightClassifier));
+                break;
         }
 
         return result;
@@ -618,6 +621,20 @@ public class Comparer(IList<IReadableNode?> _left, IList<IReadableNode?> _right)
         List<IDifference> result = [];
 
         if (!leftAnn.EqualsIdentity(rightAnn))
+        {
+            result.Add(new ClassifierDifference(left, right));
+        }
+
+        return result;
+    }
+
+    /// Compares <paramref name="leftClassifier"/> and <paramref name="rightClassifier"/>.
+    protected virtual List<IDifference> CompareClassifier(IReadableNode left, Classifier leftClassifier, IReadableNode right,
+        Classifier rightClassifier)
+    {
+        List<IDifference> result = [];
+
+        if (!leftClassifier.EqualsIdentity(rightClassifier))
         {
             result.Add(new ClassifierDifference(left, right));
         }

--- a/test/LionWeb.Core.Test/Utilities/Comparer/ComparerNodeTests.cs
+++ b/test/LionWeb.Core.Test/Utilities/Comparer/ComparerNodeTests.cs
@@ -73,6 +73,24 @@ public class ComparerNodeTests : ComparerTestsBase
     }
 
     [TestMethod]
+    public void Annotation_Concept_Ignored()
+    {
+        var left = lF.NewDocumentation("b");
+        var right = rF.NewLine("a");
+
+        var parent = new NodeDifference(left, right);
+        IDifference[] differences = [parent, new IncompatibleClassifierDifference(left, right) { Parent = parent } ];
+        Comparer comparer = new Comparer([(IReadableNode?)left], [right])
+        {
+            BehaviorConfig = new()
+            {
+                CompareCompatibleClassifier = false
+            }
+        };
+        Assert.IsTrue(comparer.AreEqual(), comparer.ToMessage(OutputConfig));
+    }
+
+    [TestMethod]
     public void Single_Null_Same()
     {
         AreEqual((INode)null, (INode)null);

--- a/test/LionWeb.Core.Test/Utilities/Comparer/ComparerNodeTests.cs
+++ b/test/LionWeb.Core.Test/Utilities/Comparer/ComparerNodeTests.cs
@@ -20,6 +20,7 @@
 namespace LionWeb.Core.Test.Utilities.Comparer;
 
 using Core.Utilities;
+using Languages.Generated.V2024_1.Shapes.M2;
 using M2;
 
 [TestClass]
@@ -73,13 +74,11 @@ public class ComparerNodeTests : ComparerTestsBase
     }
 
     [TestMethod]
-    public void Annotation_Concept_Ignored()
+    public void Annotation_Concept_Ignored_Same()
     {
         var left = lF.NewDocumentation("b");
-        var right = rF.NewLine("a");
+        var right = new LenientNode("r", ShapesLanguage.Instance.Documentation);
 
-        var parent = new NodeDifference(left, right);
-        IDifference[] differences = [parent, new IncompatibleClassifierDifference(left, right) { Parent = parent } ];
         Comparer comparer = new Comparer([(IReadableNode?)left], [right])
         {
             BehaviorConfig = new()
@@ -88,6 +87,27 @@ public class ComparerNodeTests : ComparerTestsBase
             }
         };
         Assert.IsTrue(comparer.AreEqual(), comparer.ToMessage(OutputConfig));
+    }
+
+    [TestMethod]
+    public void Annotation_Concept_Ignored_Different()
+    {
+        var left = lF.NewDocumentation("b");
+        var right = rF.NewLine("a");
+
+        Comparer comparer = new Comparer([(IReadableNode?)left], [right])
+        {
+            BehaviorConfig = new()
+            {
+                CompareCompatibleClassifier = false
+            }
+        };
+        
+        var actual = comparer.Compare().Distinct().ToList();
+        var parent = new NodeDifference(left, right);
+        List<IDifference> expected = [parent, new ClassifierDifference(left, right) { Parent = parent } ];
+
+        CollectionAssert.AreEqual(expected, actual, comparer.ToMessage(OutputConfig));
     }
 
     [TestMethod]


### PR DESCRIPTION
Introduced ComparerBehaviorConfig.CompareCompatibleClassifier to configure whether instances of C# Annotation and Concept should be considered different.