### PR TITLE
Add support for handling "ChildMovedAndReplacedFromOtherContainment"

### DIFF
--- a/src/LionWeb.Core/Core/M1/Event/Partition/PartitionEventReplicator.cs
+++ b/src/LionWeb.Core/Core/M1/Event/Partition/PartitionEventReplicator.cs
@@ -68,6 +68,9 @@ public class PartitionEventReplicator : EventReplicatorBase<IPartitionEvent, IPa
             case ChildMovedInSameContainmentEvent a:
                 OnRemoteChildMovedInSameContainment(sender, a);
                 break;
+            case ChildMovedAndReplacedFromOtherContainmentEvent a:
+                OnRemoteChildMovedAndReplacedFromOtherContainment(sender, a);
+                break;
             case AnnotationAddedEvent a:
                 OnRemoteAnnotationAdded(sender, a);
                 break;
@@ -250,6 +253,16 @@ public class PartitionEventReplicator : EventReplicatorBase<IPartitionEvent, IPa
 
             localNewParent.Set(childMovedEvent.NewContainment, newValue);
         });
+
+    private void OnRemoteChildMovedAndReplacedFromOtherContainment(object? sender,
+        ChildMovedAndReplacedFromOtherContainmentEvent childMovedAndReplacedEvent) => SuppressEventForwarding(childMovedAndReplacedEvent, () =>
+    {
+        var localNewParent = Lookup(childMovedAndReplacedEvent.NewParent.GetId());
+        var nodeToInsert = LookupOpt(childMovedAndReplacedEvent.MovedChild.GetId()) ?? Clone((INode)childMovedAndReplacedEvent.MovedChild);
+        var newValue = InsertContainment(localNewParent, childMovedAndReplacedEvent.NewContainment, childMovedAndReplacedEvent.NewIndex, nodeToInsert);
+        
+        localNewParent.Set(childMovedAndReplacedEvent.NewContainment, newValue);
+    });
 
     private void OnRemoteChildMovedFromOtherContainmentInSameParent(object? sender,
         ChildMovedFromOtherContainmentInSameParentEvent childMovedEvent) =>

--- a/src/LionWeb.Protocol.Delta/Client/DeltaEventToPartitionEventMapper.cs
+++ b/src/LionWeb.Protocol.Delta/Client/DeltaEventToPartitionEventMapper.cs
@@ -56,6 +56,7 @@ public class DeltaEventToPartitionEventMapper
             ChildMovedFromOtherContainment a => OnChildMovedFromOtherContainment(a),
             ChildMovedFromOtherContainmentInSameParent a => OnChildMovedFromOtherContainmentInSameParent(a),
             ChildMovedInSameContainment a => OnChildMovedInSameContainment(a),
+            ChildMovedAndReplacedFromOtherContainment a => OnChildMovedAndReplacedFromOtherContainment(a),
             AnnotationAdded a => OnAnnotationAdded(a),
             AnnotationDeleted a => OnAnnotationDeleted(a),
             AnnotationMovedFromOtherParent a => OnAnnotationMovedFromOtherParent(a),
@@ -173,6 +174,30 @@ public class DeltaEventToPartitionEventMapper
             childMovedEvent.OldIndex,
             ToEventId(childMovedEvent)
         );
+    }
+    
+    private ChildMovedAndReplacedFromOtherContainmentEvent OnChildMovedAndReplacedFromOtherContainment(ChildMovedAndReplacedFromOtherContainment childMovedAndReplacedEvent)
+    {
+        var movedChild = ToNode(childMovedAndReplacedEvent.MovedChild);
+        var oldParent = (IWritableNode)movedChild.GetParent();
+        var oldContainment = oldParent.GetContainmentOf(movedChild);
+
+        var newParent = ToNode(childMovedAndReplacedEvent.NewParent);
+        var newContainment = ToContainment(childMovedAndReplacedEvent.NewContainment, newParent);
+
+        var replacedChild = ToNode(childMovedAndReplacedEvent.ReplacedChild);
+
+        return new ChildMovedAndReplacedFromOtherContainmentEvent(
+            newParent, 
+            newContainment,
+            childMovedAndReplacedEvent.NewIndex,
+            movedChild,
+            oldParent, 
+            oldContainment, 
+            0,
+            replacedChild,
+            ToEventId(childMovedAndReplacedEvent)
+            );
     }
 
     private ChildMovedFromOtherContainmentInSameParentEvent OnChildMovedFromOtherContainmentInSameParent(

--- a/src/LionWeb.Protocol.Delta/Client/PartitionEventToDeltaCommandMapper.cs
+++ b/src/LionWeb.Protocol.Delta/Client/PartitionEventToDeltaCommandMapper.cs
@@ -52,6 +52,7 @@ public class PartitionEventToDeltaCommandMapper
             ChildMovedFromOtherContainmentInSameParentEvent a =>
                 OnChildMovedFromOtherContainmentInSameParent(a),
             ChildMovedInSameContainmentEvent a => OnChildMovedInSameContainment(a),
+            ChildMovedAndReplacedFromOtherContainmentEvent a => OnChildMovedAndReplacedFromOtherContainment(a),
             AnnotationAddedEvent a => OnAnnotationAdded(a),
             AnnotationDeletedEvent a => OnAnnotationDeleted(a),
             AnnotationMovedFromOtherParentEvent a => OnAnnotationMovedFromOtherParent(a),
@@ -139,6 +140,18 @@ public class PartitionEventToDeltaCommandMapper
             []
         );
 
+    private MoveAndReplaceChildFromOtherContainment 
+        OnChildMovedAndReplacedFromOtherContainment(ChildMovedAndReplacedFromOtherContainmentEvent childMovedAndReplacedEvent) => 
+        new(
+            childMovedAndReplacedEvent.NewParent.GetId(),
+            childMovedAndReplacedEvent.NewContainment.ToMetaPointer(),
+            childMovedAndReplacedEvent.NewIndex,
+            childMovedAndReplacedEvent.ReplacedChild.GetId(),
+            childMovedAndReplacedEvent.MovedChild.GetId(),
+            ToCommandId(childMovedAndReplacedEvent),
+            []
+        );
+    
     private MoveChildFromOtherContainmentInSameParent OnChildMovedFromOtherContainmentInSameParent(
         ChildMovedFromOtherContainmentInSameParentEvent childMovedEvent) =>
         new(

--- a/src/LionWeb.Protocol.Delta/Repository/DeltaCommandToPartitionEventMapper.cs
+++ b/src/LionWeb.Protocol.Delta/Repository/DeltaCommandToPartitionEventMapper.cs
@@ -56,6 +56,7 @@ public class DeltaCommandToPartitionEventMapper
             MoveChildFromOtherContainment a => OnMoveChildFromOtherContainment(a),
             MoveChildFromOtherContainmentInSameParent a => OnMoveChildFromOtherContainmentInSameParent(a),
             MoveChildInSameContainment a => OnMoveChildInSameContainment(a),
+            MoveAndReplaceChildFromOtherContainment a => OnMoveAndReplaceChildFromOtherContainment(a),
             AddAnnotation a => OnAddAnnotation(a),
             DeleteAnnotation a => OnDeleteAnnotation(a),
             MoveAnnotationFromOtherParent a => OnMoveAnnotationFromOtherParent(a),
@@ -172,6 +173,30 @@ public class DeltaCommandToPartitionEventMapper
             oldContainment,
             0, // TODO FIXME
             ToEventId(moveChildEvent)
+        );
+    }
+    
+    private ChildMovedAndReplacedFromOtherContainmentEvent OnMoveAndReplaceChildFromOtherContainment(MoveAndReplaceChildFromOtherContainment moveAndReplaceChildEvent)
+    {
+        var movedChild = ToNode(moveAndReplaceChildEvent.MovedChild);
+        var oldParent = (IWritableNode)movedChild.GetParent();
+        var oldContainment = oldParent.GetContainmentOf(movedChild);
+
+        var newParent = ToNode(moveAndReplaceChildEvent.NewParent);
+        var newContainment = ToContainment(moveAndReplaceChildEvent.NewContainment, newParent);
+        
+        var replacedChild = ToNode(moveAndReplaceChildEvent.ReplacedChild);
+
+        return new ChildMovedAndReplacedFromOtherContainmentEvent(
+            newParent, 
+            newContainment, 
+            moveAndReplaceChildEvent.NewIndex,
+            movedChild,
+            oldParent,
+            oldContainment,
+            0,
+            replacedChild,
+            ToEventId(moveAndReplaceChildEvent)
         );
     }
 

--- a/src/LionWeb.Protocol.Delta/Repository/PartitionEventToDeltaEventMapper.cs
+++ b/src/LionWeb.Protocol.Delta/Repository/PartitionEventToDeltaEventMapper.cs
@@ -51,6 +51,7 @@ public class PartitionEventToDeltaEventMapper
             ChildMovedFromOtherContainmentEvent a => OnChildMovedFromOtherContainment(a),
             ChildMovedFromOtherContainmentInSameParentEvent a => OnChildMovedFromOtherContainmentInSameParent(a),
             ChildMovedInSameContainmentEvent a => OnChildMovedInSameContainment(a),
+            ChildMovedAndReplacedFromOtherContainmentEvent a => OnChildMovedAndReplacedFromOtherContainment(a), 
             AnnotationAddedEvent a => OnAnnotationAdded(a),
             AnnotationDeletedEvent a => OnAnnotationDeleted(a),
             AnnotationMovedFromOtherParentEvent a => OnAnnotationMovedFromOtherParent(a),
@@ -145,6 +146,22 @@ public class PartitionEventToDeltaEventMapper
             []
         );
 
+    private ChildMovedAndReplacedFromOtherContainment
+        OnChildMovedAndReplacedFromOtherContainment(ChildMovedAndReplacedFromOtherContainmentEvent childMovedAndReplacedEvent) =>
+        new(
+            childMovedAndReplacedEvent.NewParent.GetId(),
+            childMovedAndReplacedEvent.NewContainment.ToMetaPointer(),
+            childMovedAndReplacedEvent.NewIndex,
+            childMovedAndReplacedEvent.MovedChild.GetId(),
+            childMovedAndReplacedEvent.OldParent.GetId(),
+            childMovedAndReplacedEvent.OldContainment.ToMetaPointer(),
+            childMovedAndReplacedEvent.OldIndex,
+            childMovedAndReplacedEvent.ReplacedChild.GetId(),
+            ToDescendants(childMovedAndReplacedEvent.ReplacedChild),
+            ToCommandSources(childMovedAndReplacedEvent), 
+            []
+            );
+    
     private ChildMovedFromOtherContainmentInSameParent OnChildMovedFromOtherContainmentInSameParent(
         ChildMovedFromOtherContainmentInSameParentEvent childMovedEvent) =>
         new(


### PR DESCRIPTION
This commit introduces logic for processing "ChildMovedAndReplacedFromOtherContainment" events across various mappers.