### PR TITLE
Fix bug in ReplaceWith method and add replication support for various notifications/events

### DIFF
--- a/src/LionWeb.Core/Core/M1/M1Extensions.cs
+++ b/src/LionWeb.Core/Core/M1/M1Extensions.cs
@@ -141,6 +141,9 @@ public static class M1Extensions
         if (parent == null)
             throw new TreeShapeException(self, "Cannot replace a node with no parent");
 
+        if (replacement is null)
+            throw new ArgumentException("Null is not a valid node");
+        
         Containment containment = parent.GetContainmentOf(self);
 
         if (containment == null)
@@ -168,8 +171,19 @@ public static class M1Extensions
                 // should not happen
                 throw new TreeShapeException(self, "Node not contained in its parent");
 
-            nodes.Insert(index, replacement);
-            nodes.Remove(self);
+            var replacementParent = replacement.GetParent();
+            var replacementContainment = replacementParent?.GetContainmentOf(replacement);
+            if (replacementContainment == containment)
+            {
+                var replacementIndex = nodes.IndexOf(replacement);
+                nodes.Insert(index, replacement);
+                nodes.RemoveAt(index + 1);
+                nodes.RemoveAt(index < replacementIndex ? nodes.LastIndexOf(replacement) : nodes.IndexOf(replacement));
+            } else
+            {
+                nodes.Insert(index, replacement);
+                nodes.Remove(self);
+            }
             parent.Set(containment, nodes);
         } else
         {

--- a/src/LionWeb.Core/Core/Notification/Pipe/RemoteReplicator.cs
+++ b/src/LionWeb.Core/Core/Notification/Pipe/RemoteReplicator.cs
@@ -93,6 +93,9 @@ public class RemoteReplicator : NotificationPipeBase, INotificationHandler
             case ChildMovedAndReplacedFromOtherContainmentInSameParentNotification e:
                 OnRemoteChildMovedAndReplacedFromOtherContainmentInSameParent(e);
                 break;
+            case ChildMovedAndReplacedInSameContainmentNotification e:
+                OnRemoteChildMovedAndReplacedInSameContainment(e);
+                break;
             case AnnotationAddedNotification e:
                 OnRemoteAnnotationAdded(e);
                 break;
@@ -282,6 +285,12 @@ public class RemoteReplicator : NotificationPipeBase, INotificationHandler
             localParent.Set(childMoved.Containment, newValue, childMoved.NotificationId);
         });
 
+    private void OnRemoteChildMovedAndReplacedInSameContainment(ChildMovedAndReplacedInSameContainmentNotification notification) =>
+        SuppressNotificationForwarding(notification, () =>
+        {
+            
+        });
+    
     private static object ReplaceContainment(INode localParent, Containment containment, Index index,
         INode substituteNode)
     {

--- a/test/LionWeb.Core.Test/NodeApi/ReplaceTests.cs
+++ b/test/LionWeb.Core.Test/NodeApi/ReplaceTests.cs
@@ -17,12 +17,157 @@
 
 namespace LionWeb.Core.Test.NodeApi;
 
+using Core.Utilities;
 using Languages.Generated.V2024_1.Shapes.M2;
 using M1;
 
 [TestClass]
 public class ReplaceTests_Containment
 {
+
+    #region Child replaced in same containment
+
+    [TestMethod]
+    public void ChildReplaced_Multiple_InSameContainment_Forward_WithTwoChildren()
+    {
+        var substituteNode = new Line("substituteNode");
+        var replaced = NewCircle("replaced");
+        
+        var actual = new Geometry("a")
+        {
+            Shapes = [substituteNode, replaced]
+        };
+        
+        replaced.ReplaceWith(substituteNode);
+        
+        var expected = new Geometry("a")
+        {
+            Shapes = [new Line("substituteNode")]
+        };
+        
+        List<IDifference> differences = new Comparer(new List<INode?> {expected}, new List<INode?> {actual}).Compare().ToList();
+        Assert.IsFalse(differences.Count != 0, differences.DescribeAll(new()));
+     
+    } 
+    
+    [TestMethod]
+    public void ChildReplaced_Multiple_InSameContainment_Backward_WithTwoChildren()
+    {
+        var substituteNode = new Line("substituteNode");
+        var replaced = NewCircle("replaced");
+        
+        var actual = new Geometry("a")
+        {
+            Shapes = [replaced, substituteNode]
+        };
+        
+        replaced.ReplaceWith(substituteNode);
+        
+        var expected = new Geometry("a")
+        {
+            Shapes = [new Line("substituteNode")]
+        };
+        
+        List<IDifference> differences = new Comparer(new List<INode?> {expected}, new List<INode?> {actual}).Compare().ToList();
+        Assert.IsFalse(differences.Count != 0, differences.DescribeAll(new()));
+    } 
+    
+    [TestMethod]
+    public void ChildReplaced_Multiple_InSameContainment_Forward_ReplaceLast()
+    {
+        var substituteNode = new Line("substituteNode");
+        var replaced = NewCircle("child");
+        
+        var actual = new Geometry("a")
+        {
+            Shapes = [NewCircle("child"), substituteNode, replaced]
+        };
+        
+        replaced.ReplaceWith(substituteNode);
+        
+        var expected = new Geometry("a")
+        {
+            Shapes = [NewCircle("child"), new Line("substituteNode")]
+        };
+        
+        List<IDifference> differences = new Comparer(new List<INode?> {expected}, new List<INode?> {actual}).Compare().ToList();
+        Assert.IsFalse(differences.Count != 0, differences.DescribeAll(new()));
+     
+    } 
+    
+    
+    [TestMethod]
+    public void ChildReplaced_Multiple_InSameContainment_Backward_ReplaceMiddle()
+    {
+        var substituteNode = new Line("substituteNode");
+        var replaced = NewCircle("replaced");
+        
+        var actual = new Geometry("a")
+        {
+            Shapes = [NewCircle("child"), replaced, substituteNode]
+        };
+        
+        replaced.ReplaceWith(substituteNode);
+        
+        var expected = new Geometry("a")
+        {
+            Shapes = [NewCircle("child"), new Line("substituteNode")]
+        };
+        
+        List<IDifference> differences = new Comparer(new List<INode?> {expected}, new List<INode?> {actual}).Compare().ToList();
+        Assert.IsFalse(differences.Count != 0, differences.DescribeAll(new()));
+     
+    } 
+    
+    [TestMethod]
+    public void ChildReplaced_Multiple_InSameContainment_Backward_ReplaceFirst()
+    {
+        var substituteNode = new Line("substituteNode");
+        var replaced = NewCircle("replaced");
+        
+        var actual = new Geometry("a")
+        {
+            Shapes = [replaced, NewCircle("child"), substituteNode]
+        };
+        
+        replaced.ReplaceWith(substituteNode);
+        
+        var expected = new Geometry("a")
+        {
+            Shapes = [new Line("substituteNode"), NewCircle("child")]
+        };
+        
+        List<IDifference> differences = new Comparer(new List<INode?> {expected}, new List<INode?> {actual}).Compare().ToList();
+        Assert.IsFalse(differences.Count != 0, differences.DescribeAll(new()));
+     
+    }
+    [TestMethod]
+    public void ChildReplaced_Multiple_InSameContainment_Backward_MoreThanThreeChildren()
+    {
+        var substituteNode = new Line("E");
+        var replaced = NewCircle("B");
+        
+        var actual = new Geometry("container")
+        {
+            Shapes = [NewCircle("A"), replaced, NewCircle("C"), NewCircle("D"), substituteNode, NewCircle("F")]
+        };
+        
+        replaced.ReplaceWith(substituteNode);
+        
+        var expected = new Geometry("container")
+        {
+            Shapes = [NewCircle("A"), new Line("E"), NewCircle("C"), NewCircle("D"), NewCircle("F")]
+        };
+        
+        List<IDifference> differences = new Comparer(new List<INode?> {expected}, new List<INode?> {actual}).Compare().ToList();
+        Assert.IsFalse(differences.Count != 0, differences.DescribeAll(new()));
+     
+    }
+
+    private Circle NewCircle(string id) => new(id) { Name = id };
+
+    #endregion
+
     [TestMethod]
     public void Beginning()
     {
@@ -77,7 +222,7 @@ public class ReplaceTests_Containment
         var circle = new Circle("circ0");
         var line = new Line("line");
 
-        Assert.ThrowsException<TreeShapeException>(() => circle.ReplaceWith(line));
+        Assert.ThrowsExactly<TreeShapeException>(() => circle.ReplaceWith(line));
     }
 
     [TestMethod]
@@ -107,7 +252,7 @@ public class ReplaceTests_Containment
             ]
         };
         var coord = new Coord("coord");
-        Assert.ThrowsException<InvalidValueException>(() => circle.ReplaceWith(coord));
+        Assert.ThrowsExactly<InvalidValueException>(() => circle.ReplaceWith(coord));
     }
 
     [TestMethod]
@@ -122,7 +267,7 @@ public class ReplaceTests_Containment
                 circle
             ]
         };
-        Assert.ThrowsException<InvalidValueException>(() => circle.ReplaceWith((INode)null));
+        Assert.ThrowsExactly<ArgumentException>(() => circle.ReplaceWith((INode)null));
     }
 }
 
@@ -170,7 +315,7 @@ public class ReplaceTests_Annotation
         var doc = new Documentation("circ0");
         var bom = new BillOfMaterials("line");
 
-        Assert.ThrowsException<TreeShapeException>(() => doc.ReplaceWith(bom));
+        Assert.ThrowsExactly<TreeShapeException>(() => doc.ReplaceWith(bom));
     }
 
     [TestMethod]
@@ -181,7 +326,7 @@ public class ReplaceTests_Annotation
         var shape = new Line("geom");
         shape.AddAnnotations([doc]);
         var coord = new Coord("coord");
-        Assert.ThrowsException<InvalidValueException>(() => doc.ReplaceWith(coord));
+        Assert.ThrowsExactly<InvalidValueException>(() => doc.ReplaceWith(coord));
     }
 
     [TestMethod]
@@ -191,6 +336,6 @@ public class ReplaceTests_Annotation
 
         var shape = new Line("geom");
         shape.AddAnnotations([doc]);
-        Assert.ThrowsException<InvalidValueException>(() => doc.ReplaceWith((INode)null));
+        Assert.ThrowsExactly<ArgumentException>(() => doc.ReplaceWith((INode)null));
     }
 }

--- a/test/LionWeb.Core.Test/Notification/CompositorTests.cs
+++ b/test/LionWeb.Core.Test/Notification/CompositorTests.cs
@@ -23,7 +23,7 @@ using Languages.Generated.V2024_1.Shapes.M2;
 using M1;
 
 [TestClass]
-public class CompositorTests
+public class CompositorTests: NotificationTestsBase
 {
     [TestMethod]
     public void ComposePartition_none()
@@ -33,7 +33,7 @@ public class CompositorTests
         var compositor = new NotificationCompositor("compositor");
         partition.GetNotificationSender()!.ConnectTo(compositor);
 
-        var counter = new NotificationCounter();
+        var counter = new NotificationObserver();
         compositor.ConnectTo(counter);
         
         partition.Documentation = new Documentation("documentation");
@@ -51,7 +51,7 @@ public class CompositorTests
         var compositor = new NotificationCompositor("compositor");
         partition.GetNotificationSender()!.ConnectTo(compositor);
 
-        var counter = new NotificationCounter();
+        var counter = new NotificationObserver();
         compositor.ConnectTo(counter);
 
         var composite = compositor.Push();
@@ -75,7 +75,7 @@ public class CompositorTests
         var compositor = new NotificationCompositor("compositor");
         partition.GetNotificationSender()!.ConnectTo(compositor);
 
-        var counter = new NotificationCounter();
+        var counter = new NotificationObserver();
         compositor.ConnectTo(counter);
 
         var composite = compositor.Push();
@@ -99,7 +99,7 @@ public class CompositorTests
         var compositor = new NotificationCompositor("compositor");
         partition.GetNotificationSender()!.ConnectTo(compositor);
 
-        var counter = new NotificationCounter();
+        var counter = new NotificationObserver();
         compositor.ConnectTo(counter);
 
         var compositeA = compositor.Push();
@@ -133,7 +133,7 @@ public class CompositorTests
         
         forest.AddPartitions([partition]);
 
-        var counter = new NotificationCounter();
+        var counter = new NotificationObserver();
         compositor.ConnectTo(counter);
 
         var composite = compositor.Push();
@@ -160,7 +160,7 @@ public class CompositorTests
         
         forest.AddPartitions([partition]);
 
-        var counter = new NotificationCounter();
+        var counter = new NotificationObserver();
         compositor.ConnectTo(counter);
 
         var composite = compositor.Push();
@@ -192,7 +192,7 @@ public class CompositorTests
         // outside counter
         forest.AddPartitions([partitionA]);
 
-        var counter = new NotificationCounter();
+        var counter = new NotificationObserver();
         compositor.ConnectTo(counter);
         
         var partitionB = new Geometry("partitionB");
@@ -220,7 +220,7 @@ public class CompositorTests
         var compositor = new NotificationCompositor("compositor");
         forest.GetNotificationSender()!.ConnectTo(compositor);
         
-        var counter = new NotificationCounter();
+        var counter = new NotificationObserver();
         compositor.ConnectTo(counter);
         
         var compositeA = compositor.Push();
@@ -267,14 +267,4 @@ public class CompositorTests
         forest.AddPartitions([partitionA]);
         Assert.AreEqual(3, counter.Count);
     }
-}
-
-internal class NotificationCounter() : NotificationPipeBase(null), INotificationReceiver
-{
-    public int Count => Notifications.Count;
-
-    public List<INotification> Notifications { get; } = [];
-
-    public void Receive(INotificationSender correspondingSender, INotification notification) =>
-        Notifications.Add(notification);
 }

--- a/test/LionWeb.Core.Test/Notification/NotificationApiUseCaseExamples.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationApiUseCaseExamples.cs
@@ -165,7 +165,7 @@ public class NotificationApiUseCaseExamples : NotificationTestsBase
         var partition = new Geometry("geo");
 
         var compositor = new NotificationCompositor("compositor");
-        var counter = new Notification.NotificationCounter();
+        var counter = new NotificationCounter();
 
         partition.GetNotificationSender()!.ConnectTo(compositor);
         compositor.ConnectTo(counter);

--- a/test/LionWeb.Core.Test/Notification/NotificationTestsBase.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationTestsBase.cs
@@ -68,15 +68,15 @@ public abstract class NotificationTestsBase
         var sharedNodeMap = new SharedNodeMap();
         var notificationMapper = new NotificationMapper(sharedNodeMap);
         var replicator = PartitionReplicator.Create(clonedPartition, sharedNodeMap, null);
-        var notificationProducer = new NotificationProducer();
+        var notificationForwarder = new NotificationForwarder();
         
-        notificationProducer.ConnectTo(notificationMapper);
+        notificationForwarder.ConnectTo(notificationMapper);
         notificationMapper.ConnectTo(replicator);
-        notificationProducer.ProduceNotification(notification);
+        notificationForwarder.ProduceNotification(notification);
     }
 }
 
-internal class NotificationProducer() : NotificationPipeBase(null), INotificationProducer
+internal class NotificationForwarder() : NotificationPipeBase(null), INotificationProducer
 {
     public void ProduceNotification(INotification notification) => Send(notification);
 }

--- a/test/LionWeb.Core.Test/Notification/NotificationTestsBase.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationTestsBase.cs
@@ -63,9 +63,9 @@ public abstract class NotificationTestsBase
         notificationMapper.ConnectTo(replicator);
     }
     
-    protected static void CreatePartitionReplicator(IPartitionInstance clonedPartition, INotification notification)
+    protected static void CreatePartitionReplicator(IPartitionInstance clonedPartition, INotification notification, SharedNodeMap? sharedNodeMap = null)
     {
-        var sharedNodeMap = new SharedNodeMap();
+        sharedNodeMap ??= new SharedNodeMap();
         var notificationMapper = new NotificationMapper(sharedNodeMap);
         var replicator = PartitionReplicator.Create(clonedPartition, sharedNodeMap, null);
         var notificationForwarder = new NotificationForwarder();

--- a/test/LionWeb.Core.Test/Notification/NotificationTestsBase.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationTestsBase.cs
@@ -63,7 +63,7 @@ public abstract class NotificationTestsBase
         notificationMapper.ConnectTo(replicator);
     }
     
-    protected static void CreatePartitionReplicator(Geometry clonedPartition, INotification notification)
+    protected static void CreatePartitionReplicator(IPartitionInstance clonedPartition, INotification notification)
     {
         var sharedNodeMap = new SharedNodeMap();
         var notificationMapper = new NotificationMapper(sharedNodeMap);

--- a/test/LionWeb.Core.Test/Notification/NotificationTestsBase.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationTestsBase.cs
@@ -72,6 +72,7 @@ public abstract class NotificationTestsBase
         
         notificationForwarder.ConnectTo(notificationMapper);
         notificationMapper.ConnectTo(replicator);
+        
         notificationForwarder.ProduceNotification(notification);
     }
 }
@@ -94,6 +95,16 @@ internal class NotificationMapper(SharedNodeMap sharedNodeMap) : NotificationPip
 
     public void Receive(INotificationSender correspondingSender, INotification notification) =>
         ProduceNotification(_notificationMapper.Map(notification));
+}
+
+internal class NotificationObserver() : NotificationPipeBase(null), INotificationReceiver
+{
+    public int Count => Notifications.Count;
+
+    public List<INotification> Notifications { get; } = [];
+
+    public void Receive(INotificationSender correspondingSender, INotification notification) =>
+        Notifications.Add(notification);
 }
 
 [Obsolete("Will be removed after tests are refactored with proper ConnectTo() calls")]

--- a/test/LionWeb.Core.Test/Notification/NotificationTestsBase.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationTestsBase.cs
@@ -31,19 +31,19 @@ public abstract class NotificationTestsBase
     protected T ClonePartition<T>(T node) where T : IPartitionInstance, INode =>
         (T)new SameIdCloner([node]) { IncludingReferences = true }.Clone()[node];
 
-    protected void AssertEquals(IEnumerable<INode?> expected, IEnumerable<INode?> actual)
+    protected static void AssertEquals(IEnumerable<INode?> expected, IEnumerable<INode?> actual)
     {
         List<IDifference> differences = new Comparer(expected.ToList(), actual.ToList()).Compare().ToList();
         Assert.IsFalse(differences.Count != 0, differences.DescribeAll(new()));
     }
 
-    protected void AssertEquals(IEnumerable<IReadableNode?> expected, IEnumerable<IReadableNode?> actual)
+    protected static void AssertEquals(IEnumerable<IReadableNode?> expected, IEnumerable<IReadableNode?> actual)
     {
         List<IDifference> differences = new Comparer(expected.ToList(), actual.ToList()).Compare().ToList();
         Assert.IsFalse(differences.Count != 0, differences.DescribeAll(new()));
     }
     
-    protected void CreateForestReplicator(IForest clonedForest, IForest originalForest)
+    protected static void CreateForestReplicator(IForest clonedForest, IForest originalForest)
     {
         var sharedNodeMap = new SharedNodeMap();
         var notificationMapper = new NotificationMapper(sharedNodeMap);
@@ -53,7 +53,7 @@ public abstract class NotificationTestsBase
         notificationMapper.ConnectTo(replicator);
     }
     
-    protected void CreatePartitionReplicator(IPartitionInstance clonedPartition, IPartitionInstance originalPartition)
+    protected static void CreatePartitionReplicator(IPartitionInstance clonedPartition, IPartitionInstance originalPartition)
     {
         var sharedNodeMap = new SharedNodeMap();
         var notificationMapper = new NotificationMapper(sharedNodeMap);
@@ -62,6 +62,23 @@ public abstract class NotificationTestsBase
         var replicator = PartitionReplicator.Create(clonedPartition, sharedNodeMap, null);
         notificationMapper.ConnectTo(replicator);
     }
+    
+    protected static void CreatePartitionReplicator(Geometry clonedPartition, INotification notification)
+    {
+        var sharedNodeMap = new SharedNodeMap();
+        var notificationMapper = new NotificationMapper(sharedNodeMap);
+        var replicator = PartitionReplicator.Create(clonedPartition, sharedNodeMap, null);
+        var notificationProducer = new NotificationProducer();
+        
+        notificationProducer.ConnectTo(notificationMapper);
+        notificationMapper.ConnectTo(replicator);
+        notificationProducer.ProduceNotification(notification);
+    }
+}
+
+internal class NotificationProducer() : NotificationPipeBase(null), INotificationProducer
+{
+    public void ProduceNotification(INotification notification) => Send(notification);
 }
 
 public interface IReplicatorCreator

--- a/test/LionWeb.Core.Test/Notification/NotificationTests_Forest.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationTests_Forest.cs
@@ -155,7 +155,7 @@ public class NotificationTests_Forest : NotificationTestsBase
 
         CreateForestReplicator(clonedForest, originalForest);
 
-        var notificationCounter = new NotificationCounter();
+        var notificationCounter = new NotificationObserver();
 
         originalForest.GetNotificationSender()!.ConnectTo(notificationCounter);
 

--- a/test/LionWeb.Core.Test/Notification/NotificationToNotificationMapper.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationToNotificationMapper.cs
@@ -58,6 +58,7 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
             ReferenceAddedNotification a => OnReferenceAdded(a),
             ReferenceDeletedNotification a => OnReferenceDeleted(a),
             ReferenceChangedNotification a => OnReferenceChanged(a),
+            EntryMovedInSameReferenceNotification a => OnEntryMovedInSameReference(a),
             _ => throw new ArgumentException($"{notification.GetType().Name} is not implemented")
         };
 
@@ -409,6 +410,20 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
             oldTarget,
             notification.NotificationId
         );
+    }
+    
+    private EntryMovedInSameReferenceNotification OnEntryMovedInSameReference(EntryMovedInSameReferenceNotification notification)
+    {
+        var parent = LookUpNode(notification.Parent);
+        var target = LookUpNode(notification.Target);
+        
+        return new EntryMovedInSameReferenceNotification(
+            parent, 
+            notification.Reference,
+            notification.OldIndex,
+            notification.NewIndex,
+            target,
+            notification.NotificationId);
     }
 
     #endregion

--- a/test/LionWeb.Core.Test/Notification/NotificationToNotificationMapper.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationToNotificationMapper.cs
@@ -50,6 +50,7 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
             ChildMovedAndReplacedFromOtherContainmentInSameParentNotification a => OnChildMovedAndReplacedFromOtherContainmentInSameParent(a),
             AnnotationAddedNotification a => OnAnnotationAdded(a),
             AnnotationDeletedNotification a => OnAnnotationDeleted(a),
+            AnnotationReplacedNotification a => OnAnnotationReplaced(a),
             AnnotationMovedFromOtherParentNotification a => OnAnnotationMovedFromOtherParent(a),
             AnnotationMovedInSameParentNotification a => OnAnnotationMovedInSameParent(a),
             ReferenceAddedNotification a => OnReferenceAdded(a),
@@ -114,7 +115,6 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
     }
 
     #endregion
-
 
     #region Children
 
@@ -256,7 +256,6 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
 
     #endregion
 
-
     #region Annotations
 
     private AnnotationAddedNotification OnAnnotationAdded(AnnotationAddedNotification notification)
@@ -283,6 +282,19 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
             notification.Index,
             notification.NotificationId
         );
+    }
+
+    private AnnotationReplacedNotification OnAnnotationReplaced(AnnotationReplacedNotification notification)
+    {
+        var newAnnotation = CloneNode(notification.NewAnnotation);
+        var parent = LookUpNode(notification.Parent);
+
+        return new AnnotationReplacedNotification(
+            newAnnotation,
+            notification.ReplacedAnnotation,
+            parent,
+            notification.Index,
+            notification.NotificationId);
     }
 
     private AnnotationMovedFromOtherParentNotification OnAnnotationMovedFromOtherParent(
@@ -374,9 +386,9 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
 
         // TODO change to correct exception (UnknownNodeIdException ?)
         throw new NotImplementedException($"Unknown node with id: {nodeId}");
-    }  
-    
-    private ReferenceTarget LookUpNode(IReferenceTarget target) 
+    }
+
+    private ReferenceTarget LookUpNode(IReferenceTarget target)
     {
         var nodeId = target.Reference.GetId();
         if (sharedNodeMap.TryGetValue(nodeId, out var result))

--- a/test/LionWeb.Core.Test/Notification/NotificationToNotificationMapper.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationToNotificationMapper.cs
@@ -51,6 +51,7 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
             AnnotationAddedNotification a => OnAnnotationAdded(a),
             AnnotationDeletedNotification a => OnAnnotationDeleted(a),
             AnnotationReplacedNotification a => OnAnnotationReplaced(a),
+            AnnotationMovedAndReplacedInSameParentNotification a => OnAnnotationMovedAndReplacedInSameParentNotification(a),
             AnnotationMovedFromOtherParentNotification a => OnAnnotationMovedFromOtherParent(a),
             AnnotationMovedInSameParentNotification a => OnAnnotationMovedInSameParent(a),
             ReferenceAddedNotification a => OnReferenceAdded(a),
@@ -324,6 +325,22 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
             movedAnnotation,
             parent,
             notification.OldIndex,
+            notification.NotificationId
+        );
+    }
+    
+    private INotification OnAnnotationMovedAndReplacedInSameParentNotification(AnnotationMovedAndReplacedInSameParentNotification notification)
+    {
+        var parent = LookUpNode(notification.Parent);
+        var movedAnnotation = LookUpNode(notification.MovedAnnotation);
+        var replacedAnnotation = LookUpNode(notification.ReplacedAnnotation);
+        
+        return new AnnotationMovedAndReplacedInSameParentNotification(
+            notification.NewIndex,
+            movedAnnotation,
+            parent,
+            notification.OldIndex,
+            replacedAnnotation,
             notification.NotificationId
         );
     }

--- a/test/LionWeb.Core.Test/Notification/NotificationToNotificationMapper.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationToNotificationMapper.cs
@@ -48,6 +48,7 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
             ChildMovedInSameContainmentNotification a => OnChildMovedInSameContainment(a),
             ChildMovedAndReplacedFromOtherContainmentNotification a => OnChildMovedAndReplacedFromOtherContainment(a),
             ChildMovedAndReplacedFromOtherContainmentInSameParentNotification a => OnChildMovedAndReplacedFromOtherContainmentInSameParent(a),
+            ChildMovedAndReplacedInSameContainmentNotification a => OnChildMovedAndReplacedInSameContainment(a),
             AnnotationAddedNotification a => OnAnnotationAdded(a),
             AnnotationDeletedNotification a => OnAnnotationDeleted(a),
             AnnotationReplacedNotification a => OnAnnotationReplaced(a),
@@ -250,6 +251,23 @@ public class NotificationToNotificationMapper(SharedNodeMap sharedNodeMap)
             movedChild,
             parent,
             notification.Containment,
+            notification.OldIndex,
+            notification.NotificationId
+        );
+    }
+
+    private ChildMovedAndReplacedInSameContainmentNotification OnChildMovedAndReplacedInSameContainment(ChildMovedAndReplacedInSameContainmentNotification notification)
+    {
+        var parent = LookUpNode(notification.Parent);
+        var movedChild = LookUpNode(notification.MovedChild);
+        var replacedChild = LookUpNode(notification.ReplacedChild);
+        
+        return new ChildMovedAndReplacedInSameContainmentNotification(
+            notification.NewIndex,
+            movedChild,
+            parent,
+            notification.Containment,
+            replacedChild,
             notification.OldIndex,
             notification.NotificationId
         );

--- a/test/LionWeb.Core.Test/Notification/NotificationsTest.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationsTest.cs
@@ -2,7 +2,6 @@
 
 using Core.Notification;
 using Core.Notification.Partition;
-using Core.Notification.Pipe;
 using Languages.Generated.V2024_1.Shapes.M2;
 using M1;
 
@@ -666,7 +665,7 @@ public class NotificationsTest : NotificationTestsBase
         var annotationReplacedNotification = new AnnotationReplacedNotification(newAnnotation, replaced, originalPartition, 
             0, new NumericNotificationId("annotationReplaced", 0));
         
-        CreateReplicator(clonedPartition, annotationReplacedNotification);
+        CreatePartitionReplicator(clonedPartition, annotationReplacedNotification);
 
         Assert.AreEqual(1, clonedPartition.GetAnnotations().Count);
         Assert.AreEqual(newAnnotation.GetId(), clonedPartition.GetAnnotations()[0].GetId());
@@ -685,7 +684,7 @@ public class NotificationsTest : NotificationTestsBase
         var annotationReplacedNotification = new AnnotationReplacedNotification(newAnnotation, replaced, originalPartition, 
             0, new NumericNotificationId("annotationReplaced", 0));
         
-        CreateReplicator(clonedPartition, annotationReplacedNotification);
+        CreatePartitionReplicator(clonedPartition, annotationReplacedNotification);
 
         Assert.AreEqual(2, clonedPartition.GetAnnotations().Count);
         Assert.AreEqual(newAnnotation.GetId(), clonedPartition.GetAnnotations()[0].GetId());
@@ -705,7 +704,7 @@ public class NotificationsTest : NotificationTestsBase
         var annotationReplacedNotification = new AnnotationReplacedNotification(newAnnotation, replaced, originalPartition, 
             index, new NumericNotificationId("annotationReplaced", 0));
         
-        CreateReplicator(clonedPartition, annotationReplacedNotification);
+        CreatePartitionReplicator(clonedPartition, annotationReplacedNotification);
 
         Assert.AreEqual(2, clonedPartition.GetAnnotations().Count);
         Assert.AreEqual(newAnnotation.GetId(), clonedPartition.GetAnnotations()[index].GetId());
@@ -730,7 +729,7 @@ public class NotificationsTest : NotificationTestsBase
         var annotationReplacedNotification = new AnnotationMovedAndReplacedInSameParentNotification(newIndex, moved, originalPartition,oldIndex, 
             replaced, new NumericNotificationId("annotationMovedAndReplaced", 0));
         
-        CreateReplicator(clonedPartition, annotationReplacedNotification);
+        CreatePartitionReplicator(clonedPartition, annotationReplacedNotification);
 
         Assert.AreEqual(1, clonedPartition.GetAnnotations().Count);
         Assert.AreEqual(moved.GetId(), clonedPartition.GetAnnotations()[0].GetId());
@@ -752,7 +751,7 @@ public class NotificationsTest : NotificationTestsBase
         var annotationReplacedNotification = new AnnotationMovedAndReplacedInSameParentNotification(newIndex, moved, originalPartition,oldIndex, 
             replaced, new NumericNotificationId("annotationMovedAndReplaced", 0));
         
-        CreateReplicator(clonedPartition, annotationReplacedNotification);
+        CreatePartitionReplicator(clonedPartition, annotationReplacedNotification);
 
         Assert.AreEqual(1, clonedPartition.GetAnnotations().Count);
         Assert.AreEqual(moved.GetId(), clonedPartition.GetAnnotations()[0].GetId());
@@ -997,22 +996,4 @@ public class NotificationsTest : NotificationTestsBase
     #endregion
 
     #endregion
-    
-    private static void CreateReplicator(Geometry clonedPartition, INotification notification)
-    {
-        var sharedNodeMap = new SharedNodeMap();
-        var notificationMapper = new NotificationMapper(sharedNodeMap);
-        var replicator = PartitionReplicator.Create(clonedPartition, sharedNodeMap, null);
-        var notificationProducer = new NotificationProducer();
-        
-        notificationProducer.ConnectTo(notificationMapper);
-        notificationMapper.ConnectTo(replicator);
-        notificationProducer.ProduceNotification(notification);
-    }
-
-    private class NotificationProducer() : NotificationPipeBase(null), INotificationProducer
-    {
-        public void ProduceNotification(INotification notification) => Send(notification);
-    }
-    
 }

--- a/test/LionWeb.Core.Test/Notification/NotificationsTest.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationsTest.cs
@@ -475,6 +475,46 @@ public class NotificationsTest : NotificationTestsBase
         AssertEquals([originalPartition], [clonedPartition]);
     }
 
+    [TestMethod]
+    [Ignore("add support in remote replicator")]
+    public void ChildMovedAndReplacedInSameContainment_Forward()
+    {
+        var moved = new Circle("moved");
+        var replaced = new Line("replaced");
+        var originalPartition = new Geometry("a") { Shapes = [moved, replaced] };
+        var clonedPartition = ClonePartition(originalPartition);
+
+        var newIndex = 1;
+        var oldIndex = 0;
+        var notification = new ChildMovedAndReplacedInSameContainmentNotification(newIndex, moved, originalPartition, ShapesLanguage.Instance.Geometry_shapes, 
+            replaced, oldIndex, new NumericNotificationId("childMovedAndReplacedInSameContainment", 0));
+
+        CreatePartitionReplicator(clonedPartition, notification);
+
+        Assert.AreEqual(1, clonedPartition.GetAnnotations().Count);
+        Assert.AreEqual(moved.GetId(), clonedPartition.GetAnnotations()[0].GetId());
+    }
+
+    [TestMethod]
+    [Ignore("add support in remote replicator")]
+    public void ChildMovedAndReplacedInSameContainment_Backward()
+    {
+        var moved = new Circle("moved");
+        var replaced = new Line("replaced");
+        var originalPartition = new Geometry("a") { Shapes = [replaced, moved] };
+        var clonedPartition = ClonePartition(originalPartition);
+
+        var newIndex = 0;
+        var oldIndex = 1;
+        var notification = new ChildMovedAndReplacedInSameContainmentNotification(newIndex, moved, originalPartition, ShapesLanguage.Instance.Geometry_shapes, 
+            replaced, oldIndex, new NumericNotificationId("childMovedAndReplacedInSameContainment", 0));
+
+        CreatePartitionReplicator(clonedPartition, notification);
+
+        Assert.AreEqual(1, clonedPartition.GetAnnotations().Count);
+        Assert.AreEqual(moved.GetId(), clonedPartition.GetAnnotations()[0].GetId());
+    }
+
     #endregion
 
     #endregion

--- a/test/LionWeb.Core.Test/Notification/NotificationsTest.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationsTest.cs
@@ -3,6 +3,7 @@
 using Core.Notification;
 using Core.Notification.Partition;
 using Languages.Generated.V2024_1.Shapes.M2;
+using Languages.Generated.V2025_1.TestLanguage;
 using M1;
 
 [TestClass]
@@ -1191,5 +1192,33 @@ public class NotificationsTest : NotificationTestsBase
 
     #endregion
 
+    #region MoveEntryInSameReference
+
+    [TestMethod]
+    public void MoveEntryInSameReference_Backward()
+    {
+        var ref1 = new LinkTestConcept("ref1");
+        var ref2 = new LinkTestConcept("ref2");
+        var moved = new LinkTestConcept("moved");
+        
+        var originalPartition = new LinkTestConcept("concept")
+        {
+            Reference_0_n = [ref1, ref2, moved]
+        };
+        
+        var clonedPartition = ClonePartition(originalPartition);
+
+        var oldIndex = 2;
+        var newIndex = 0;
+        var notification = new EntryMovedInSameReferenceNotification(originalPartition, TestLanguageLanguage.Instance.LinkTestConcept_reference_0_n,
+            oldIndex, newIndex, new ReferenceTarget {Reference = moved}, new NumericNotificationId("moveEntryInSameReference", 0));
+        
+        CreatePartitionReplicator(clonedPartition, notification);
+        
+        Assert.AreEqual(moved.GetId(), clonedPartition.Reference_0_n[0].GetId());
+    }
+
+    #endregion
+    
     #endregion
 }

--- a/test/LionWeb.Core.Test/Notification/NotificationsTest.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationsTest.cs
@@ -1213,9 +1213,43 @@ public class NotificationsTest : NotificationTestsBase
         var notification = new EntryMovedInSameReferenceNotification(originalPartition, TestLanguageLanguage.Instance.LinkTestConcept_reference_0_n,
             oldIndex, newIndex, new ReferenceTarget {Reference = moved}, new NumericNotificationId("moveEntryInSameReference", 0));
         
-        CreatePartitionReplicator(clonedPartition, notification);
+        var sharedNodeMap = new SharedNodeMap();
+        sharedNodeMap.RegisterNode(ref1);
+        sharedNodeMap.RegisterNode(ref2);
+        sharedNodeMap.RegisterNode(moved);
+        
+        CreatePartitionReplicator(clonedPartition, notification, sharedNodeMap);
         
         Assert.AreEqual(moved.GetId(), clonedPartition.Reference_0_n[0].GetId());
+    }
+
+    [TestMethod]
+    public void MoveEntryInSameReference_Forward()
+    {
+        var ref1 = new LinkTestConcept("ref1");
+        var ref2 = new LinkTestConcept("ref2");
+        var moved = new LinkTestConcept("moved");
+        
+        var originalPartition = new LinkTestConcept("concept")
+        {
+            Reference_0_n = [moved, ref1, ref2]
+        };
+        
+        var clonedPartition = ClonePartition(originalPartition);
+
+        var oldIndex = 0;
+        var newIndex = 2;
+        var notification = new EntryMovedInSameReferenceNotification(originalPartition, TestLanguageLanguage.Instance.LinkTestConcept_reference_0_n,
+            oldIndex, newIndex, new ReferenceTarget {Reference = moved}, new NumericNotificationId("moveEntryInSameReference", 0));
+        
+        var sharedNodeMap = new SharedNodeMap();
+        sharedNodeMap.RegisterNode(ref1);
+        sharedNodeMap.RegisterNode(ref2);
+        sharedNodeMap.RegisterNode(moved);
+        
+        CreatePartitionReplicator(clonedPartition, notification, sharedNodeMap);
+        
+        Assert.AreEqual(moved.GetId(), clonedPartition.Reference_0_n[^1].GetId());
     }
 
     #endregion

--- a/test/LionWeb.Core.Test/Notification/NotificationsTest.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationsTest.cs
@@ -668,6 +668,7 @@ public class NotificationsTest : NotificationTestsBase
         
         CreateReplicator(clonedPartition, annotationReplacedNotification);
 
+        Assert.AreEqual(1, clonedPartition.GetAnnotations().Count);
         Assert.AreEqual(newAnnotation.GetId(), clonedPartition.GetAnnotations()[0].GetId());
     }
 
@@ -686,6 +687,7 @@ public class NotificationsTest : NotificationTestsBase
         
         CreateReplicator(clonedPartition, annotationReplacedNotification);
 
+        Assert.AreEqual(2, clonedPartition.GetAnnotations().Count);
         Assert.AreEqual(newAnnotation.GetId(), clonedPartition.GetAnnotations()[0].GetId());
     }
 
@@ -705,9 +707,58 @@ public class NotificationsTest : NotificationTestsBase
         
         CreateReplicator(clonedPartition, annotationReplacedNotification);
 
+        Assert.AreEqual(2, clonedPartition.GetAnnotations().Count);
         Assert.AreEqual(newAnnotation.GetId(), clonedPartition.GetAnnotations()[index].GetId());
     }
     
+    #endregion
+
+    #region AnnotationMovedAndReplacedInSameParent
+
+    [TestMethod]
+    public void AnnotationMovedAndReplacedInSameParent_Forward()
+    {
+        var replaced = new BillOfMaterials("replaced");
+        var moved = new BillOfMaterials("moved");
+        var originalPartition = new Geometry("a");
+        originalPartition.AddAnnotations([moved, replaced]);
+        
+        var clonedPartition = ClonePartition(originalPartition);
+
+        var newIndex = 1;
+        var oldIndex = 0;
+        var annotationReplacedNotification = new AnnotationMovedAndReplacedInSameParentNotification(newIndex, moved, originalPartition,oldIndex, 
+            replaced, new NumericNotificationId("annotationMovedAndReplaced", 0));
+        
+        CreateReplicator(clonedPartition, annotationReplacedNotification);
+
+        Assert.AreEqual(1, clonedPartition.GetAnnotations().Count);
+        Assert.AreEqual(moved.GetId(), clonedPartition.GetAnnotations()[0].GetId());
+    }
+    
+    
+    [TestMethod]
+    public void AnnotationMovedAndReplacedInSameParent_Backward()
+    {
+        var replaced = new BillOfMaterials("replaced");
+        var moved = new BillOfMaterials("moved");
+        var originalPartition = new Geometry("a");
+        originalPartition.AddAnnotations([replaced, moved]);
+        
+        var clonedPartition = ClonePartition(originalPartition);
+
+        var newIndex = 0;
+        var oldIndex = 1;
+        var annotationReplacedNotification = new AnnotationMovedAndReplacedInSameParentNotification(newIndex, moved, originalPartition,oldIndex, 
+            replaced, new NumericNotificationId("annotationMovedAndReplaced", 0));
+        
+        CreateReplicator(clonedPartition, annotationReplacedNotification);
+
+        Assert.AreEqual(1, clonedPartition.GetAnnotations().Count);
+        Assert.AreEqual(moved.GetId(), clonedPartition.GetAnnotations()[0].GetId());
+    }
+    
+
     #endregion
 
     #endregion


### PR DESCRIPTION
Replicator now handles the following events:

- EntryMovedInSameReference
- AnnotationMovedAndReplacedInSameParent 
- AnnotationReplaced 
- ChildMovedAndReplacedInSameContainment 