### PR TITLE
Prevent redundant operations when references remain unchanged

### DIFF
--- a/src/LionWeb.Core/Core/M1/M1Extensions.cs
+++ b/src/LionWeb.Core/Core/M1/M1Extensions.cs
@@ -137,6 +137,9 @@ public static class M1Extensions
     /// <exception cref="TreeShapeException">If <paramref name="self"/> has no parent.</exception>
     public static T ReplaceWith<T>(this INode self, T replacement) where T : INode
     {
+        if (ReferenceEquals(self, replacement))
+            return (T)self;
+        
         INode? parent = self.GetParent();
         if (parent == null)
             throw new TreeShapeException(self, "Cannot replace a node with no parent");

--- a/src/LionWeb.Core/Core/Notification/Partition/Emitter/ReferenceSingleNotificationEmitter.cs
+++ b/src/LionWeb.Core/Core/Notification/Partition/Emitter/ReferenceSingleNotificationEmitter.cs
@@ -43,6 +43,9 @@ public class ReferenceSingleNotificationEmitter : ReferenceNotificationEmitterBa
         if (!IsActive())
             return;
 
+        if (ReferenceEquals(_oldTarget, _newTarget))
+            return;
+        
         switch (_oldTarget, _newTarget)
         {
             case (null, { } v):

--- a/test/LionWeb.Core.Test/Notification/NotificationTests_Reference.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationTests_Reference.cs
@@ -21,6 +21,7 @@ using Core.Notification;
 using Core.Notification.Partition;
 using Languages.Generated.V2025_1.Shapes.M2;
 using Languages.Generated.V2025_1.TestLanguage;
+using M1;
 
 [TestClass]
 public class NotificationTests_Reference : NotificationTestsBase
@@ -186,7 +187,39 @@ public class NotificationTests_Reference : NotificationTestsBase
 
         AssertEquals([originalPartition], [clonedPartition]);
     }
+    
+    [TestMethod]
+    public void ReferenceChanged_NoOps_test()
+    {
+        var circle = new Circle("circle");
+        var line = new Line("line");
+        var od = new OffsetDuplicate("od") { AltSource = circle };
+        var originalPartition = new Geometry("a") { Shapes = [od, circle, line] };
 
+        var notificationObserver = new NotificationObserver();
+        originalPartition.GetNotificationSender()!.ConnectTo(notificationObserver);
+
+        od.AltSource = circle;
+        
+        Assert.AreEqual(0, notificationObserver.Count);
+    }
+    
+    [TestMethod]
+    public void ReferenceChanged_NoOps_test_ReplaceWith()
+    {
+        var circle = new Circle("circle");
+        var line = new Line("line");
+        var od = new OffsetDuplicate("od") { AltSource = circle };
+        var originalPartition = new Geometry("a") { Shapes = [od, circle, line] };
+
+        var notificationObserver = new NotificationObserver();
+        originalPartition.GetNotificationSender()!.ConnectTo(notificationObserver);
+
+        od.AltSource.ReplaceWith(circle);
+        
+        Assert.AreEqual(0, notificationObserver.Count);
+    }
+    
     #endregion
 
     #region ReferenceTarget


### PR DESCRIPTION
Added early return checks to avoid unnecessary notifications and operations when references or nodes are not modified.