### PR TITLE
Refactor variable naming from `substituteNode` to `replacement` 

### DIFF
--- a/test/LionWeb.Core.Test/NodeApi/ReplaceTests.cs
+++ b/test/LionWeb.Core.Test/NodeApi/ReplaceTests.cs
@@ -30,19 +30,19 @@ public class ReplaceTests_Containment
     [TestMethod]
     public void ChildReplaced_Multiple_InSameContainment_Forward_WithTwoChildren()
     {
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         var replaced = NewCircle("replaced");
         
         var actual = new Geometry("a")
         {
-            Shapes = [substituteNode, replaced]
+            Shapes = [replacement, replaced]
         };
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         var expected = new Geometry("a")
         {
-            Shapes = [new Line("substituteNode")]
+            Shapes = [new Line("replacement")]
         };
         
         AssertEquals([expected], [actual]);
@@ -51,19 +51,19 @@ public class ReplaceTests_Containment
     [TestMethod]
     public void ChildReplaced_Multiple_InSameContainment_Backward_WithTwoChildren()
     {
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         var replaced = NewCircle("replaced");
         
         var actual = new Geometry("a")
         {
-            Shapes = [replaced, substituteNode]
+            Shapes = [replaced, replacement]
         };
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         var expected = new Geometry("a")
         {
-            Shapes = [new Line("substituteNode")]
+            Shapes = [new Line("replacement")]
         };
         
         AssertEquals([expected], [actual]);
@@ -72,19 +72,19 @@ public class ReplaceTests_Containment
     [TestMethod]
     public void ChildReplaced_Multiple_InSameContainment_Forward_ReplaceLast()
     {
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         var replaced = NewCircle("child");
         
         var actual = new Geometry("a")
         {
-            Shapes = [NewCircle("child"), substituteNode, replaced]
+            Shapes = [NewCircle("child"), replacement, replaced]
         };
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         var expected = new Geometry("a")
         {
-            Shapes = [NewCircle("child"), new Line("substituteNode")]
+            Shapes = [NewCircle("child"), new Line("replacement")]
         };
         
         AssertEquals([expected], [actual]);
@@ -94,19 +94,19 @@ public class ReplaceTests_Containment
     [TestMethod]
     public void ChildReplaced_Multiple_InSameContainment_Backward_ReplaceMiddle()
     {
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         var replaced = NewCircle("replaced");
         
         var actual = new Geometry("a")
         {
-            Shapes = [NewCircle("child"), replaced, substituteNode]
+            Shapes = [NewCircle("child"), replaced, replacement]
         };
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         var expected = new Geometry("a")
         {
-            Shapes = [NewCircle("child"), new Line("substituteNode")]
+            Shapes = [NewCircle("child"), new Line("replacement")]
         };
         
         AssertEquals([expected], [actual]);
@@ -115,19 +115,19 @@ public class ReplaceTests_Containment
     [TestMethod]
     public void ChildReplaced_Multiple_InSameContainment_Backward_ReplaceFirst()
     {
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         var replaced = NewCircle("replaced");
         
         var actual = new Geometry("a")
         {
-            Shapes = [replaced, NewCircle("child"), substituteNode]
+            Shapes = [replaced, NewCircle("child"), replacement]
         };
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         var expected = new Geometry("a")
         {
-            Shapes = [new Line("substituteNode"), NewCircle("child")]
+            Shapes = [new Line("replacement"), NewCircle("child")]
         };
         
         AssertEquals([expected], [actual]);
@@ -136,15 +136,15 @@ public class ReplaceTests_Containment
     [TestMethod]
     public void ChildReplaced_Multiple_InSameContainment_Backward_MoreThanThreeChildren()
     {
-        var substituteNode = new Line("E");
+        var replacement = new Line("E");
         var replaced = NewCircle("B");
         
         var actual = new Geometry("container")
         {
-            Shapes = [NewCircle("A"), replaced, NewCircle("C"), NewCircle("D"), substituteNode, NewCircle("F")]
+            Shapes = [NewCircle("A"), replaced, NewCircle("C"), NewCircle("D"), replacement, NewCircle("F")]
         };
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         var expected = new Geometry("container")
         {

--- a/test/LionWeb.Core.Test/Notification/NotificationTests_Containment.cs
+++ b/test/LionWeb.Core.Test/Notification/NotificationTests_Containment.cs
@@ -223,7 +223,7 @@ public class NotificationTests_Containment: NotificationTestsBase
     public void ChildReplaced_Multiple_Only()
     {
         var replaced = new Circle("replaced");
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         
         var originalPartition = new Geometry("a")
         {
@@ -236,7 +236,7 @@ public class NotificationTests_Containment: NotificationTestsBase
         var notificationObserver = new NotificationObserver();
         originalPartition.GetNotificationSender()!.ConnectTo(notificationObserver);
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
 
         Assert.AreEqual(1, notificationObserver.Count);
         Assert.IsInstanceOfType<ChildReplacedNotification>(notificationObserver.Notifications[0]);
@@ -256,14 +256,14 @@ public class NotificationTests_Containment: NotificationTestsBase
 
         CreatePartitionReplicator(clonedPartition, originalPartition);
 
-        var substituteNode = new Line("substituteNode");
-        var childReplacedNotification = new ChildReplacedNotification(substituteNode, replaced, originalPartition, 
+        var replacement = new Line("replacement");
+        var childReplacedNotification = new ChildReplacedNotification(replacement, replaced, originalPartition, 
             ShapesLanguage.Instance.Geometry_shapes, 0, new NumericNotificationId("childReplacedNotification", 0));
         
         CreatePartitionReplicator(clonedPartition, childReplacedNotification);
         
         Assert.AreEqual(1, clonedPartition.Shapes.Count);
-        Assert.AreEqual(substituteNode.GetId(), clonedPartition.Shapes[0].GetId());
+        Assert.AreEqual(replacement.GetId(), clonedPartition.Shapes[0].GetId());
     }
     
     [TestMethod]
@@ -271,7 +271,7 @@ public class NotificationTests_Containment: NotificationTestsBase
     public void ChildReplaced_Multiple_First()
     {
         var replaced = new Circle("replaced");
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         
         var originalPartition = new Geometry("a")
         {
@@ -284,7 +284,7 @@ public class NotificationTests_Containment: NotificationTestsBase
         var notificationObserver = new NotificationObserver();
         originalPartition.GetNotificationSender()!.ConnectTo(notificationObserver);
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         Assert.AreEqual(1, notificationObserver.Count);
         Assert.IsInstanceOfType<ChildReplacedNotification>(notificationObserver.Notifications[0]);
@@ -295,7 +295,7 @@ public class NotificationTests_Containment: NotificationTestsBase
     public void ChildReplaced_Multiple_First_ProducesNotification()
     {
         var replaced = new Circle("replaced");
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         
         var originalPartition = new Geometry("a")
         {
@@ -303,13 +303,13 @@ public class NotificationTests_Containment: NotificationTestsBase
         };
         var clonedPartition = ClonePartition(originalPartition);
         
-        var childReplacedNotification = new ChildReplacedNotification(substituteNode, replaced, originalPartition, 
+        var childReplacedNotification = new ChildReplacedNotification(replacement, replaced, originalPartition, 
             ShapesLanguage.Instance.Geometry_shapes, 0, new NumericNotificationId("childReplacedNotification", 0));
         
         CreatePartitionReplicator(clonedPartition, childReplacedNotification);
         
         Assert.AreEqual(2, clonedPartition.Shapes.Count);
-        Assert.AreEqual(substituteNode.GetId(), clonedPartition.Shapes[0].GetId());
+        Assert.AreEqual(replacement.GetId(), clonedPartition.Shapes[0].GetId());
     }
 
     [TestMethod]
@@ -317,7 +317,7 @@ public class NotificationTests_Containment: NotificationTestsBase
     public void ChildReplaced_Multiple_Last()
     {
         var replaced = new Circle("replaced");
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         
         var originalPartition = new Geometry("a")
         {
@@ -330,7 +330,7 @@ public class NotificationTests_Containment: NotificationTestsBase
         var notificationObserver = new NotificationObserver();
         originalPartition.GetNotificationSender()!.ConnectTo(notificationObserver);
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
 
         Assert.AreEqual(1, notificationObserver.Count);
         Assert.IsInstanceOfType<ChildReplacedNotification>(notificationObserver.Notifications[0]);
@@ -341,7 +341,7 @@ public class NotificationTests_Containment: NotificationTestsBase
     public void ChildReplaced_Multiple_Last_ProducesNotification()
     {
         var replaced = new Circle("replaced");
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         
         var originalPartition = new Geometry("a")
         {
@@ -349,13 +349,13 @@ public class NotificationTests_Containment: NotificationTestsBase
         };
         var clonedPartition = ClonePartition(originalPartition);
 
-        var childReplacedNotification = new ChildReplacedNotification(substituteNode, replaced, originalPartition, 
+        var childReplacedNotification = new ChildReplacedNotification(replacement, replaced, originalPartition, 
             ShapesLanguage.Instance.Geometry_shapes, 1, new NumericNotificationId("childReplacedNotification", 0));
         
         CreatePartitionReplicator(clonedPartition, childReplacedNotification);
         
         Assert.AreEqual(2, clonedPartition.Shapes.Count);
-        Assert.AreEqual(substituteNode.GetId(), clonedPartition.Shapes[^1].GetId());
+        Assert.AreEqual(replacement.GetId(), clonedPartition.Shapes[^1].GetId());
     }
     
     #endregion
@@ -366,12 +366,12 @@ public class NotificationTests_Containment: NotificationTestsBase
     [Ignore("Should emit ChildMovedAndReplacedInSameContainmentNotification")]
     public void ChildMovedAndReplacedInSameContainment_Backward()
     {
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         var replaced = new Circle("replaced");
         
         var originalPartition = new Geometry("a")
         {
-            Shapes = [new Circle("child"), replaced, substituteNode]
+            Shapes = [new Circle("child"), replaced, replacement]
         };
         var clonedPartition = ClonePartition(originalPartition);
 
@@ -380,7 +380,7 @@ public class NotificationTests_Containment: NotificationTestsBase
         var notificationObserver = new NotificationObserver();
         originalPartition.GetNotificationSender()!.ConnectTo(notificationObserver);
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         Assert.AreEqual(1, notificationObserver.Count);
         Assert.IsInstanceOfType<ChildMovedAndReplacedInSameContainmentNotification>(notificationObserver.Notifications[0]);
@@ -410,12 +410,12 @@ public class NotificationTests_Containment: NotificationTestsBase
     [Ignore("Should emit ChildMovedAndReplacedInSameContainmentNotification")]
     public void ChildMovedAndReplacedInSameContainment_Forward()
     {
-        var substituteNode = new Line("substituteNode");
+        var replacement = new Line("replacement");
         var replaced = new Circle("replaced");
         
         var originalPartition = new Geometry("a")
         {
-            Shapes = [new Circle("child"), substituteNode, replaced]
+            Shapes = [new Circle("child"), replacement, replaced]
         };
         var clonedPartition = ClonePartition(originalPartition);
 
@@ -424,7 +424,7 @@ public class NotificationTests_Containment: NotificationTestsBase
         var notificationObserver = new NotificationObserver();
         originalPartition.GetNotificationSender()!.ConnectTo(notificationObserver);
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         Assert.AreEqual(1, notificationObserver.Count);
         Assert.IsInstanceOfType<ChildMovedAndReplacedInSameContainmentNotification>(notificationObserver.Notifications[0]);
@@ -453,51 +453,51 @@ public class NotificationTests_Containment: NotificationTestsBase
     [TestMethod]
     public void ChildMovedAndReplacedInSameContainment_Backward_MoreThanThreeChildren_ProducesNotification()
     {
-        var substituteNode = new Line("E");
+        var replacement = new Line("E");
         var replaced = new Circle("B");
         
         var originalPartition = new Geometry("container")
         {
-            Shapes = [new Circle("A"), replaced, new Circle("C"), new Circle("D"), substituteNode, new Circle("F")]
+            Shapes = [new Circle("A"), replaced, new Circle("C"), new Circle("D"), replacement, new Circle("F")]
         };
         var clonedPartition = ClonePartition(originalPartition);
         
         var newIndex = 1;
         var oldIndex = 4;
-        var notification = new ChildMovedAndReplacedInSameContainmentNotification(newIndex, substituteNode, originalPartition, ShapesLanguage.Instance.Geometry_shapes, 
+        var notification = new ChildMovedAndReplacedInSameContainmentNotification(newIndex, replacement, originalPartition, ShapesLanguage.Instance.Geometry_shapes, 
             replaced, oldIndex, new NumericNotificationId("childMovedAndReplacedInSameContainment", 0));
 
         CreatePartitionReplicator(clonedPartition, notification);
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         Assert.AreEqual(5, clonedPartition.Shapes.Count);
-        Assert.AreEqual(substituteNode.GetId(), clonedPartition.Shapes[1].GetId());
+        Assert.AreEqual(replacement.GetId(), clonedPartition.Shapes[1].GetId());
     }
     
     [TestMethod]
     public void ChildMovedAndReplacedInSameContainment_Forward_MoreThanThreeChildren_ProducesNotification()
     {
-        var substituteNode = new Line("E");
+        var replacement = new Line("E");
         var replaced = new Circle("B");
         
         var originalPartition = new Geometry("container")
         {
-            Shapes = [new Circle("A"), substituteNode, new Circle("C"), new Circle("D"), replaced, new Circle("F")]
+            Shapes = [new Circle("A"), replacement, new Circle("C"), new Circle("D"), replaced, new Circle("F")]
         };
         var clonedPartition = ClonePartition(originalPartition);
         
         var newIndex = 4;
         var oldIndex = 1;
-        var notification = new ChildMovedAndReplacedInSameContainmentNotification(newIndex, substituteNode, originalPartition, ShapesLanguage.Instance.Geometry_shapes, 
+        var notification = new ChildMovedAndReplacedInSameContainmentNotification(newIndex, replacement, originalPartition, ShapesLanguage.Instance.Geometry_shapes, 
             replaced, oldIndex, new NumericNotificationId("childMovedAndReplacedInSameContainment", 0));
 
         CreatePartitionReplicator(clonedPartition, notification);
         
-        replaced.ReplaceWith(substituteNode);
+        replaced.ReplaceWith(replacement);
         
         Assert.AreEqual(5, clonedPartition.Shapes.Count);
-        Assert.AreEqual(substituteNode.GetId(), clonedPartition.Shapes[^2].GetId());
+        Assert.AreEqual(replacement.GetId(), clonedPartition.Shapes[^2].GetId());
     }
 
     #endregion


### PR DESCRIPTION
Renamed all instances of `substituteNode` to `replacement` across tests and code for consistency and clarity.