### PR TITLE
Use nodeId-compatible strings for commandId everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres _loosely_ to [Semantic Versioning](https://semver.org/s
 ## [0.4.7] - tbd
 ### Added
 ### Fixed
+* Use nodeId-compatible strings for commandId everywhere.
 ### Changed
 * Enabled AOT-optimized JSON (de)serialization for delta messages.
 * Delta message JSON are not formatted (pretty-printed) anymore.

--- a/src/LionWeb.Core/Core/Notification/INotification.cs
+++ b/src/LionWeb.Core/Core/Notification/INotification.cs
@@ -27,4 +27,16 @@ public interface INotification
 }
 
 /// ID of a notification in the LionWeb notification system.
-public interface INotificationId;
+public interface INotificationId
+{
+    /// <summary>
+    /// Participation id, if available; <c>null</c> otherwise.
+    /// </summary>
+    string? ParticipationId { get; }
+    
+    /// <summary>
+    /// CommandId, must be set.
+    /// </summary>
+    string CommandId { get; }
+    
+};

--- a/src/LionWeb.Core/Core/Notification/NumericNotificationId.cs
+++ b/src/LionWeb.Core/Core/Notification/NumericNotificationId.cs
@@ -23,6 +23,12 @@ using Utilities;
 public record NumericNotificationId(string Base, int Id) : INotificationId
 {
     /// <inheritdoc />
+    public string? ParticipationId => null;
+
+    /// <inheritdoc />
+    public string CommandId => Base + "__" + Id;
+
+    /// <inheritdoc />
     public virtual bool Equals(NumericNotificationId? other)
     {
         if (other is null)

--- a/src/LionWeb.Protocol.Delta/Message/Event/IDeltaEvent.cs
+++ b/src/LionWeb.Protocol.Delta/Message/Event/IDeltaEvent.cs
@@ -23,7 +23,15 @@ using Core.Serialization;
 using System.Text;
 using System.Text.Json.Serialization;
 
-public record CommandSource(ParticipationId ParticipationId, CommandId CommandId);
+public record CommandSource(ParticipationId ParticipationId, CommandId CommandId)
+{
+    /// <summary>
+    /// Represents this command source as NodeId-compatible string.
+    /// </summary>
+    /// <returns></returns>
+    public string AsId() =>
+        ParticipationId + "__" + CommandId;
+};
 
 /// <remarks>
 /// IMPORTANT: Make sure to update attributes on <see cref="IDeltaContent"/> in lockstep.
@@ -116,7 +124,7 @@ public abstract record DeltaEventBase(
 {
     /// <inheritdoc />
     [JsonIgnore]
-    public override string Id => string.Join("__", OriginCommands.Select(x => x.ToString()));
+    public override string Id => string.Join("___", OriginCommands.Select(x => x.AsId()));
 
     /// <inheritdoc />
     public virtual EventSequenceNumber SequenceNumber { get; set; } = IDeltaEvent.DefaultEventSequenceNumber;

--- a/src/LionWeb.Protocol.Delta/Repository/NotificationToDeltaEventMapper.cs
+++ b/src/LionWeb.Protocol.Delta/Repository/NotificationToDeltaEventMapper.cs
@@ -342,20 +342,6 @@ public class NotificationToDeltaEventMapper
     private TargetNode[] ToDescendants(IReadableNode node) =>
         M1Extensions.Descendants(node, false, true).Select(n => n.GetId()).ToArray();
 
-    private CommandSource[] ToCommandSources(INotification notification)
-    {
-        ParticipationId participationId;
-        EventId commandId;
-        if (notification.NotificationId is ParticipationNotificationId pei)
-        {
-            participationId = pei.ParticipationId;
-            commandId = pei.CommandId;
-        } else
-        {
-            participationId = _participationIdProvider.Create();
-            commandId = notification.NotificationId.ToString();
-        }
-
-        return [new CommandSource(participationId, commandId)];
-    }
+    private CommandSource[] ToCommandSources(INotification notification) => 
+        [new(notification.NotificationId.ParticipationId ?? _participationIdProvider.Create(), notification.NotificationId.CommandId)];
 }

--- a/test/LionWeb.Protocol.Delta.Test/Json/JsonSerializationTests.cs
+++ b/test/LionWeb.Protocol.Delta.Test/Json/JsonSerializationTests.cs
@@ -17,6 +17,12 @@
 
 namespace LionWeb.Protocol.Delta.Test.Json;
 
+using Core.Notification;
+using Core.Notification.Partition;
+using Core.Test.Languages.Generated.V2024_1.TestLanguage;
+using Core.Utilities;
+using Delta.Client;
+using Delta.Repository;
 using Message;
 using Message.Command;
 using Message.Event;
@@ -64,7 +70,7 @@ public class JsonSerializationTests : JsonTestsBase
         // see https://github.com/LionWeb-io/specification/issues/351
         if (@event is CompositeEvent ce)
             @event = ce with { SequenceNumber = IDeltaEvent.DefaultEventSequenceNumber };
-        
+
         var deltaSerializer = new DeltaSerializer();
         var compositeEvent = new CompositeEvent([@event], []);
         var serialized = deltaSerializer.Serialize(compositeEvent);
@@ -81,5 +87,58 @@ public class JsonSerializationTests : JsonTestsBase
         var serialized = deltaSerializer.Serialize(CreateAddChild());
 
         Assert.IsFalse(Regex.IsMatch(serialized, "\\s"), serialized);
+    }
+
+    [TestMethod]
+    public void SerializeNumericNotificationId()
+    {
+        var notification = new PropertyAddedNotification(new DataTypeTestConcept("nodeId"), TestLanguageLanguage.Instance.DataTypeTestConcept_booleanValue_0_1, true,
+            new NumericNotificationId("myBase", 23));
+
+        var lionWebVersion = TestLanguageLanguage.Instance.LionWebVersion;
+        var deltaSerializer = new DeltaSerializer();
+
+        var deltaCommand = new NotificationToDeltaCommandMapper(new CommandIdProvider(), lionWebVersion).Map(notification);
+        Assert.IsTrue(IdUtils.IsValid(deltaCommand.Id));
+        Assert.IsTrue(IdUtils.IsValid(deltaCommand.CommandId!));
+        var serializedCommand = deltaSerializer.Serialize(deltaCommand);
+        Assert.AreEqual(
+            """{"messageKind":"AddProperty","node":"nodeId","property":{"language":"TestLanguage","version":"0","key":"DataTypeTestConcept-booleanValue_0_1"},"newValue":"true","commandId":"1","additionalInfos":[]}""",
+            serializedCommand);
+
+        var deltaEvent = new NotificationToDeltaEventMapper(new ParticipationIdProvider(), lionWebVersion).Map(notification);
+        Assert.IsTrue(IdUtils.IsValid(deltaEvent.Id));
+        Assert.IsTrue(IdUtils.IsValid(deltaEvent.OriginCommands![0].CommandId));
+        Assert.IsTrue(IdUtils.IsValid(deltaEvent.OriginCommands![0].ParticipationId));
+        var serializedEvent = deltaSerializer.Serialize(deltaEvent);
+        Assert.AreEqual(
+            """{"messageKind":"PropertyAdded","node":"nodeId","property":{"language":"TestLanguage","version":"0","key":"DataTypeTestConcept-booleanValue_0_1"},"newValue":"true","sequenceNumber":-1,"originCommands":[{"participationId":"participationId1","commandId":"myBase__23"}],"additionalInfos":[]}""",
+            serializedEvent);
+    }
+
+    [TestMethod]
+    public void SerializeParticipationNotificationId()
+    {
+        var notification = new PropertyAddedNotification(new DataTypeTestConcept("nodeId"), TestLanguageLanguage.Instance.DataTypeTestConcept_booleanValue_0_1, true,
+            new ParticipationNotificationId("myParticipation", "myCommand"));
+
+        var lionWebVersion = TestLanguageLanguage.Instance.LionWebVersion;
+        var deltaSerializer = new DeltaSerializer();
+
+        var deltaCommand = new NotificationToDeltaCommandMapper(new CommandIdProvider(), lionWebVersion).Map(notification);
+        Assert.IsTrue(IdUtils.IsValid(deltaCommand.Id));
+        Assert.IsTrue(IdUtils.IsValid(deltaCommand.CommandId!));
+        var serializedCommand = deltaSerializer.Serialize(deltaCommand);
+        Assert.AreEqual(
+            """{"messageKind":"AddProperty","node":"nodeId","property":{"language":"TestLanguage","version":"0","key":"DataTypeTestConcept-booleanValue_0_1"},"newValue":"true","commandId":"myCommand","additionalInfos":[]}""",
+            serializedCommand);
+        var deltaEvent = new NotificationToDeltaEventMapper(new ParticipationIdProvider(), lionWebVersion).Map(notification);
+        Assert.IsTrue(IdUtils.IsValid(deltaEvent.Id));
+        Assert.IsTrue(IdUtils.IsValid(deltaEvent.OriginCommands![0].CommandId));
+        Assert.IsTrue(IdUtils.IsValid(deltaEvent.OriginCommands![0].ParticipationId));
+        var serializedEvent = deltaSerializer.Serialize(deltaEvent);
+        Assert.AreEqual(
+            """{"messageKind":"PropertyAdded","node":"nodeId","property":{"language":"TestLanguage","version":"0","key":"DataTypeTestConcept-booleanValue_0_1"},"newValue":"true","sequenceNumber":-1,"originCommands":[{"participationId":"myParticipation","commandId":"myCommand"}],"additionalInfos":[]}""",
+            serializedEvent);
     }
 }


### PR DESCRIPTION
fixes #200 